### PR TITLE
fix missing 'void *id' parameter to print() call that didn't get enough testing.

### DIFF
--- a/src/protocols/d0.c
+++ b/src/protocols/d0.c
@@ -278,7 +278,7 @@ size_t meter_read_d0(meter_t *mtr, reading_t rds[], size_t max_readings) {
 	}
 
 error:
-	print(log_error, "%s(): read unexpected byte: %x: %s%c%c!", __FUNCTION__, byte,isprint(byte)?"\"":"(non-printabl",isprint(byte)?byte:'e',isprint(byte)?'"':')');
+	print(log_error, "%s(): read unexpected byte: %x: %s%c%c!", mtr, __FUNCTION__, byte,isprint(byte)?"\"":"(non-printabl",isprint(byte)?byte:'e',isprint(byte)?'"':')');
 	return 0;
 }
 


### PR DESCRIPTION
fix missing 'void *id' parameter to print() call that didn't get enough testing.

TODO: add GNU magic to function call to have print's printf-style parameter list checked by compiler...
