### PR TITLE
Added support for TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,26 @@
+language: cpp
+
+compiler: 
+    - clang 
+    - gcc
+
+notifications:
+    mail: "volkszaehler-dev@lists.volkszaehler.org"
+    irc: "chat.freenode.net#volkszaehler.org"
+
+before_install:
+  - sudo apt-get update -qq
+  - sudo apt-get install -y libjson0-dev libcurl4-openssl-dev openssl libmicrohttpd-dev uuid-dev uuid-runtime
+# -- get libsml --
+  - git clone https://github.com/TheCount/libsml.git # or https://github.com/dailab/libsml.git
+  - cd libsml 
+  - git checkout develop # only dev branch seems to work
+  - make
+# -- install libsml --
+  - sudo cp sml/lib/libsml.* /usr/lib/. 
+  - sudo cp -R sml/include/* /usr/include/.
+  - sudo cp sml.pc /usr/lib/pkgconfig/.
+  - cd ..
+
+script:
+  - cmake . -DSML_HOME=/usr/local/src/libsml/sml && make && make test


### PR DESCRIPTION
Add continuous integration with TravisCI. For now, in the absence of unit tests, it is only validated if vzlogger does actually build. Both gcc and clang are configured.

One note on libsml: the "official repository" linked from http://wiki.volkszaehler.org/software/controller/vzlogger/installation_cpp-version doesn't compile (examples are broken). The travis build script uses https://github.com/TheCount/libsml/tree/develop instead.

@TheCount: perhaps you could check if the wiki needs updating?
