### PR TITLE
unit test for Obis and bugfix for #58

### DIFF
--- a/src/Obis.cpp
+++ b/src/Obis.cpp
@@ -36,6 +36,10 @@
 #include <VZException.hpp>
 
 #define DC 0xff // wildcard, dont care
+#define SC_C 96 // special character "C" has obis code 96 according to http://www.mayor.de/lian98/doc.de/pdf/vdew-lh-lastgangzaehler-2127b3.pdf
+#define SC_F 97
+#define SC_L 98
+#define SC_P 99
 
 //const Obis::aliases[] = {
 static obis_alias_t aliases[] = {
@@ -159,8 +163,20 @@ int Obis::parse(const char *str) {
 	for (int i = 0; i < len; i++) {
 		byte = str[i];
 
-		if (isxdigit(byte)) {
-			num = (num * 10) + (byte - '0'); /* parse digits */
+		if (isdigit(byte)) {
+				num = (num * 10) + (byte - '0'); /* parse digits */
+		}
+		else if (byte == 'C') {
+				num = SC_C;
+		}
+		else if (byte == 'F') {
+				num = SC_F;
+		}
+		else if (byte == 'L') {
+				num = SC_L;
+		}
+		else if (byte == 'P') {
+				num = SC_P;
 		}
 		else {
 			if (byte == '-' && field < A) {		/* end of field A */

--- a/tests/ut_obis.cpp
+++ b/tests/ut_obis.cpp
@@ -1,0 +1,40 @@
+#include "gtest/gtest.h"
+#include "Obis.hpp"
+#include "VZException.hpp"
+
+// dirty hack until we find a better solution:
+// (already in MeterD0.cpp) #include "../src/Obis.cpp"
+
+TEST(Obis, Obis_basic) {
+	// empty Obis constructor
+	Obis o1;
+	ASSERT_TRUE(o1.isNull());
+	ASSERT_TRUE(!o1.isManufacturerSpecific());
+
+	// 2nd constructor:
+	Obis o2(0x1, 0x2, 0x3, 0x4, 0x5, 0x6);
+	ASSERT_EQ(o2, o2); // check comparison op.
+	// 3rd constructor:
+	Obis o3("1-2:3.4.5*6");
+	ASSERT_EQ(o2, o3);
+}
+
+TEST(Obis, Obis_strparsing) {
+	Obis o1(0x1, 0x1, 97, 97, 0xff, 0xff); // 97 = SC_F
+	Obis o2("1-1:F.F");
+	ASSERT_EQ(o1, o2);
+
+	Obis o3(0x1, 0x1, 96, 98, 0xff, 0xff); // 96 = SC_C, 98 = SC_L
+	Obis o4("1-1:C.L");
+	ASSERT_EQ(o3, o4);
+
+	Obis o5(0x1, 0x1, 96, 99, 0xff, 0xff); // 96 = SC_C, 99 = SC_P
+	Obis o6("1-1:C.P");
+	ASSERT_EQ(o5, o6);
+
+	ASSERT_THROW(Obis o7("1-1:x:y"), vz::VZException);
+	Obis o8("power-l1");
+	ASSERT_EQ(Obis("1-0:21.7"), o8);
+
+}
+


### PR DESCRIPTION
Added unit tests for Obis (basic ones) as requested within #55.
Fixed bug #58. Used Obis codes 96-99 for special chars C,F,L and P.
Remark: the obis parser still accepts a lot of invalid strings like "1-1:F4:3C",... but this would need a major rework of the parser.
