### PR TITLE
configure cmake for debug build, on by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,9 @@ set(PACKAGE_STRING "${PROJECT_NAME} ${VZLOGGER_RPM_VERSION}")
 set(VERSION "${VZLOGGER_RPM_VERSION}")
 set(CMAKE_VERBOSE_MAKEFILE 1)
 
+# debug build, on by default
+ADD_DEFINITIONS(-g3)
+
 ###########################################################
 # Where are the additional libraries installed? Note: provide includes
 # path here, subsequent checks will resolve everything else


### PR DESCRIPTION
merge this or the commented out version.
i would prefer to have it on by default,
to allow us to debug right away if people complain about crashes.
