### PR TITLE
fix interface to libsml

### DIFF
--- a/include/Obis.hpp
+++ b/include/Obis.hpp
@@ -47,6 +47,7 @@ class Obis {
 
 	bool isManufacturerSpecific() const;
 	bool isNull() const;
+	bool isValid() const;
 
 	private:
 	int parse(const char *str);

--- a/include/protocols/MeterSML.hpp
+++ b/include/protocols/MeterSML.hpp
@@ -71,8 +71,9 @@ protected:
 	 *
 	 * @param list the list entry
 	 * @param rd the reading to store to
+	 * @return true if it is a valid entry
 	 */
-	void _parse(sml_list *list, Reading *rd);
+	bool _parse(sml_list *list, Reading *rd);
 
 	/**
 	 * Open serial port by device

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -11,4 +11,6 @@ target_link_libraries(vzlogger_unit_tests
     ${GTEST_LIBS_DIR}/libgtest.a
     ${GTEST_LIBS_DIR}/libgtest_main.a
     ${JSON_LIBRARY}
+    ${SML_LIBRARY}
+    ${LIBUUID}
     pthread)

--- a/tests/MeterSML.cpp
+++ b/tests/MeterSML.cpp
@@ -1,0 +1,179 @@
+#include <stdio.h>
+
+#include "gtest/gtest.h"
+#include "Options.hpp"
+#include "protocols/MeterSML.hpp"
+
+// this is a dirty hack. we should think about better ways/rules to link against the
+// test objects.
+// e.g. single files in the tests directory that just include the real file. This way one
+// will avoid multiple includes of the same file in a different test case
+// (or linking against the real file from the CMakeLists.txt)
+
+#include "../src/protocols/MeterSML.cpp"
+
+int writes_hex(int fd, const char *str)
+{
+	int toret=0;
+	// expect each string as a hexdump. two chars for each byte:
+	int len = strlen(str);
+	EXPECT_EQ(0, len%2); // strlen should be even.
+	for (int i=0; i<len; i+=2){
+		unsigned char c;
+		sscanf(&str[i], "%2hhx", &c);
+		int r = write(fd, &c, 1);
+		if (r==-1) return r;
+		toret += r;
+	}
+	return toret;
+}
+
+TEST(MeterSML, EMH_basic) {
+	char tempfilename[L_tmpnam+1];
+	ASSERT_NE(tmpnam_r(tempfilename), (char*)0);
+	std::list<Option> options;
+	options.push_back(Option("device", tempfilename));
+	MeterSML m(options);
+	ASSERT_STREQ(m.device(), tempfilename) << "devicename not eq " << tempfilename;
+	ASSERT_EQ(0, mkfifo(tempfilename, S_IRUSR|S_IWUSR));
+	int fd = open(tempfilename, O_RDWR);
+	ASSERT_NE(-1, fd);
+	ASSERT_NE(-1, m.open());
+
+	// now we can simulate some input by simply writing into fd
+	std::vector<Reading> rds;
+	rds.resize(10);
+
+	// write one good data set
+	writes_hex(fd, "1B1B1B1B010101017607003600001AFA6200620072630101760101070036044808FE09303232383038313601016331ED007607003600001AFB62006200726307017701093032323830383136017262016504487D897677078181C78203FF0101010104454D480177070100000000FF010101010930323238303831360177070100010801FF63018001621E52FF560008D1CF1B0177070100010802FF63018001621E52FF560000004E9C01770700006001FFFF010101010B303030323238303831360177070100010700FF0101621B52FF550000007001010163D201007607003600001AFC6200620072630201710163077A00001B1B1B1B1A019D37");
+	/*
+	 * manual parsing of input data:
+	 * 1B1B1B1B
+	 * 01010101
+	 * 76 TL Field list of.., len = 6
+	 *  07 1. list element, TL Field : octet string, len 6 (why not 7?)
+	 *   003600001AFA  =transaction id
+	 *  62 00 2nd list element, TL field: u8, val=0 =group id
+	 *  62 00 3rd list element, TL field: u8, val=0 =abort on error
+	 *  72 4th list element, TL list of, len = 2 =message body
+	 *   630101 1st elem, TL u16, val=101 =tag ("public open req")
+	 *   76 2nd elem, TL list of, len = 6
+	 *    01 opt codepage
+	 *    01  opt clientid
+	 *    07 str, len 6= 0036044808FE reqFileId
+	 *    09 3032323830383136 serverId
+	 *    01 opt time
+	 *    01 opt version
+	 *  63 5th elem, u16, val = 31ED =crc16
+	 *  00 6th elem EndOfSMLMsg
+	 * 76 list of, len=6
+	 *  07 tl octet string, len 6 = 003600001AFB = transaction id
+	 *  62 u8, 00 =groupid
+	 *  62 u8, 00 =abort on error
+	 *  72 list, len=2 = message body
+	 *   63 0701 =tag (get list response)
+	 *   77 = message body data list with 7 elements
+	 *    01 opt clientid
+	 *    09 str, len 8 =3032323830383136 serverId
+	 *    01 opt listname
+	 *    72 actSensorTime
+	 *     62 u8, val=01
+	 *     65 u32, val=04487D89
+	 *    76 valList
+	 *     77
+	 *      07 str, l 6 =8181C78203FF objName 129-129:xC7... -> error code
+	 *      01 opt status
+	 *      01 opt valTime
+	 *      01 opt unit
+	 *      01 opt scaler
+	 *      04 str, l3 =454D48 value
+	 *      01 opt valueSignature
+	 *     77
+	 *      07 str, l 6 =0100000000FF objName 1-0:0.0.0*FF
+	 *      01
+	 *      01
+	 *      01
+	 *      01
+	 *      09 str, l 8 =3032323830383136 "02280816" Eigentumsnr?
+	 *      01
+	 *     77
+	 *      07 str, l 6 =0100010801FF objName 1-0:1.8.1*FF
+	 *      63 u16 =0180 status
+	 *      01
+	 *      62 u8, =1E unit -> Wh
+	 *      52 s8, =FF scaler (-> 10⁻1)
+	 *      56 signed int len 5 byte 0008D1CF1B
+	 *      01
+	 *     77
+	 *      07 str l 6 =0100010802FF objName 1-0:1.8.2*FF
+	 *      63 u16 =0180
+	 *      01
+	 *      62 u8 =1E
+	 *      52 s8 = FF
+	 *      56 s int, len 5 byte 0000004E9C
+	 *      01
+	 *     77
+	 *      07 str l 6 =00006001FFFF 0-0:96.1.FF*FF
+	 *      01
+	 *      01
+	 *      01
+	 *      01
+	 *      0B str l 10 = 30303032323830383136 "0002280816"
+	 *      01
+	 *     77
+	 *      07 str l 6 =0100010700FF objName 1-0:1.7.0*FF
+	 *      01
+	 *      01
+	 *      62 u8 = 1B unit
+	 *      52 s8 = FF scaler-> 10⁻1
+	 *      55 s int32 = 00000070 -> 112 -> 11.2
+	 *      01
+	 *    01 opt listSignature
+	 *    01 opt actGatewayTime
+	 *   63 u16 =D201 crc16
+	 *   00 EndOfSMLMsg
+	 *  76
+	 *   07 str l 6 = 003600001AFC
+	 *   62 u8 = 00
+	 *   62 u8 = 00
+	 *   72
+	 *    63 u16 = 0201
+	 *    71
+	 *     01
+	 *   63 u16 = 077A crc
+	 *   00 EndOfSMLMsg
+	 *  00
+	 *  1B1B1B1B
+	 *  1A019D37
+	 */
+	// now read 3 readings: (currently the string values get's ignored. See MeterSML::_parse
+	EXPECT_EQ(3, m.read(rds, 3));
+	// check obis data:
+	ReadingIdentifier *p = rds[0].identifier().get();
+	double value = rds[0].value();
+	EXPECT_LE(abs(14796777.1-value), 0.1);
+	ObisIdentifier *o = dynamic_cast<ObisIdentifier*>(p);
+	ASSERT_NE((ObisIdentifier*)0, o);
+	EXPECT_TRUE(Obis(1, 0, 1, 8, 1, 255)==(o->obis()));
+
+	o = dynamic_cast<ObisIdentifier*>(rds[1].identifier().get());
+	ASSERT_NE((ObisIdentifier*)0, o);
+	value = rds[1].value();
+	EXPECT_EQ(2012.4, value);
+	EXPECT_TRUE(Obis(1, 0, 1, 8, 2, 255)==(o->obis()));
+
+	o = dynamic_cast<ObisIdentifier*>(rds[2].identifier().get());
+	ASSERT_NE((ObisIdentifier*)0, o);
+	value = rds[2].value();
+	EXPECT_LE(abs(11.2-value), 0.1);
+	EXPECT_TRUE(Obis(1, 0, 1, 7, 0, 255)==(o->obis()));
+
+
+	EXPECT_EQ(0, m.close());
+
+	EXPECT_EQ(0, close(fd));
+	EXPECT_EQ(0, unlink(tempfilename));
+}
+
+
+

--- a/tests/ut_obis.cpp
+++ b/tests/ut_obis.cpp
@@ -1,0 +1,40 @@
+#include "gtest/gtest.h"
+#include "Obis.hpp"
+#include "VZException.hpp"
+
+// dirty hack until we find a better solution:
+// (already in MeterD0.cpp) #include "../src/Obis.cpp"
+
+TEST(Obis, Obis_basic) {
+	// empty Obis constructor
+	Obis o1;
+	ASSERT_TRUE(o1.isNull());
+	ASSERT_TRUE(!o1.isManufacturerSpecific());
+
+	// 2nd constructor:
+	Obis o2(0x1, 0x2, 0x3, 0x4, 0x5, 0x6);
+	ASSERT_EQ(o2, o2); // check comparison op.
+	// 3rd constructor:
+	Obis o3("1-2:3.4.5*6");
+	ASSERT_EQ(o2, o3);
+}
+
+TEST(Obis, Obis_strparsing) {
+	Obis o1(0x1, 0x1, 97, 97, 0xff, 0xff); // 97 = SC_F
+	Obis o2("1-1:F.F");
+	ASSERT_EQ(o1, o2);
+
+	Obis o3(0x1, 0x1, 96, 98, 0xff, 0xff); // 96 = SC_C, 98 = SC_L
+	Obis o4("1-1:C.L");
+	ASSERT_EQ(o3, o4);
+
+	Obis o5(0x1, 0x1, 96, 99, 0xff, 0xff); // 96 = SC_C, 99 = SC_P
+	Obis o6("1-1:C.P");
+	ASSERT_EQ(o5, o6);
+
+	ASSERT_THROW(Obis o7("1-1:x:y"), vz::VZException);
+	Obis o8("power-l1");
+	ASSERT_EQ(Obis("1-0:21.7"), o8);
+
+}
+


### PR DESCRIPTION
- Ignore string entries and not valid entries like error codes (81 81 ...). Refer to issue #29 this removes the "unknown type error from libxml". Unknown type have actually been octet strings.
- Report correct number of readings. There was always a +1 wrongly reported and the octet string ones that get ignored now. Discussed as part of #63.
- Added basic unit test for MeterSML using the example data provided by devZer0 from #63.
- Includes unit test for Obis and fix for Obis (isxdigit -> isdigit and ...) (replaces/includes #59)

With those changes now correctly just 3 readings get extracted from the example data.
Needs good testing with SML based meters. I will support debugging any occurring problems.
