### PR TITLE
fix cmake -DENABLE_LOCAL=on

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,6 +62,7 @@ if(ENABLE_LOCAL)
   include(FindMicroHttpd)
   if(MICROHTTPD_FOUND)
     set(MICROHTTPD_SUPPORT 1)
+    set(LOCAL_SUPPORT 1)
   endif(MICROHTTPD_FOUND)
 endif(ENABLE_LOCAL)
 


### PR DESCRIPTION
 (to generate "#define LOCAL_SUPPORT 1" in config.h)
fix https://github.com/volkszaehler/vzlogger/issues/73
