### PR TITLE
Fix build without libsml

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,7 +128,7 @@ message("             sml:  -L${SML_LIBRARY} -I${SML_INCLUDE_DIR}")
 message("             microhttpd: -L${MICROHTTPD_LIBRARY} -I${MICROHTTPD_INCLUDE_DIR}")
 
 if( NOT SML_FOUND)
-  message(FATAL_ERROR "libsml ist required.
+  message(WARNING "libsml ist required.
 Install libsml or call cmake -DSML_HOME=path_to_sml_install")
 endif( NOT SML_FOUND)
 if( NOT MICROHTTPD_FOUND )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,7 +128,7 @@ message("             sml:  -L${SML_LIBRARY} -I${SML_INCLUDE_DIR}")
 message("             microhttpd: -L${MICROHTTPD_LIBRARY} -I${MICROHTTPD_INCLUDE_DIR}")
 
 if( NOT SML_FOUND)
-  message(WARNING "libsml ist required.
+  message(WARNING "libsml was not found.
 Install libsml or call cmake -DSML_HOME=path_to_sml_install")
 endif( NOT SML_FOUND)
 if( NOT MICROHTTPD_FOUND )

--- a/src/Meter.cpp
+++ b/src/Meter.cpp
@@ -36,7 +36,9 @@
 #include <protocols/MeterFluksoV2.hpp>
 #include <protocols/MeterRandom.hpp>
 #include <protocols/MeterS0.hpp>
+#ifdef SML_SUPPORT
 #include <protocols/MeterSML.hpp>
+#endif
 //#include <protocols/.h>
 
 #define METER_DETAIL(NAME, CLASSNAME, DESC, MAX_RDS, PERIODIC) {				\
@@ -151,10 +153,12 @@ Meter::Meter(std::list<Option> pOptions) :
 			_protocol = vz::protocol::Protocol::Ptr(new MeterD0(pOptions));
 			_identifier = ReadingIdentifier::Ptr(new ObisIdentifier());
 			break;
+#ifdef SML_SUPPORT
 		case  meter_protocol_sml:
 			_protocol = vz::protocol::Protocol::Ptr(new MeterSML(pOptions));
 			_identifier = ReadingIdentifier::Ptr(new ObisIdentifier());
 			break;
+#endif
 		case meter_protocol_fluksov2:
 			_protocol = vz::protocol::Protocol::Ptr(new MeterFluksoV2(pOptions));
 			_identifier = ReadingIdentifier::Ptr(new ChannelIdentifier());


### PR DESCRIPTION
vzlogger can now be build without libsml.
there were just two ifdefs in Meter.cpp missing,
and cmake should not abort if libsml was not found.
(config to conditonally compile MeterSML.cpp was already present)

(this could be cleaned up a little, we could abort if sml was explicitly requested but not found, but i'm not that familiar with cmake either)