### PR TITLE
added googlemock framework

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,11 @@ notifications:
     irc: "chat.freenode.net#volkszaehler.org"
 
 before_install:
+
+  - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
   - sudo apt-get update -qq
+  - if [ "$CXX" = "g++" ]; then sudo apt-get install -qq g++-4.8; fi
+  - if [ "$CXX" = "g++" ]; then export CXX="g++-4.8" CC="gcc-4.8"; fi
   - sudo apt-get install -y libjson0-dev libcurl4-openssl-dev openssl libmicrohttpd-dev uuid-dev uuid-runtime
 # -- get libsml --
   - git clone https://github.com/TheCount/libsml.git # or https://github.com/dailab/libsml.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,9 +111,10 @@ myconfigure_file(
   )
 
 add_subdirectory(src)
+
 find_package(Subversion)
 if(Subversion_FOUND)
-  add_subdirectory(gtest)
+  add_subdirectory(gmock)
   add_subdirectory(tests)
 else()
   message(WARNING "googletest based unit tests disabled due to missing subversion! Please install svn.")

--- a/gmock/CMakeLists.txt
+++ b/gmock/CMakeLists.txt
@@ -1,0 +1,24 @@
+cmake_minimum_required(VERSION 2.8.0)
+project(gmock_builder C CXX)
+include(ExternalProject)
+
+ExternalProject_Add(googlemock
+    SVN_REPOSITORY http://googlemock.googlecode.com/svn/tags/release-1.7.0/
+    CMAKE_ARGS
+     PREFIX "${CMAKE_CURRENT_BINARY_DIR}"
+# Disable install step
+    INSTALL_COMMAND ""
+# Avoid svn update each time on make
+    UPDATE_COMMAND ""
+)
+
+# Specify include dir
+ExternalProject_Get_Property(googlemock source_dir)
+set(GMOCK_INCLUDE_DIRS ${source_dir}/include PARENT_SCOPE)
+set(GTEST_INCLUDE_DIRS ${source_dir}/gtest/include PARENT_SCOPE)
+
+# Specify MainTest's link libraries
+ExternalProject_Get_Property(googlemock binary_dir)
+set(GTEST_LIBS_DIR ${binary_dir}/gtest PARENT_SCOPE)
+set(GMOCK_LIBS_DIR ${binary_dir} PARENT_SCOPE)
+

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,15 +1,16 @@
 include_directories(
+    ${GMOCK_INCLUDE_DIRS}
     ${GTEST_INCLUDE_DIRS}
 )
 
-# all *.cpp files here will be used. No main() required as we link with gtest_main
+# all *.cpp files here will be used.
 file(GLOB test_sources *.cpp)
 
 add_executable(vzlogger_unit_tests ${test_sources})
 
 target_link_libraries(vzlogger_unit_tests
     ${GTEST_LIBS_DIR}/libgtest.a
-    ${GTEST_LIBS_DIR}/libgtest_main.a
+    ${GMOCK_LIBS_DIR}/libgmock.a
     ${JSON_LIBRARY}
     ${SML_LIBRARY}
     ${LIBUUID}

--- a/tests/example_test.cpp
+++ b/tests/example_test.cpp
@@ -1,6 +1,23 @@
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
- 
+
+class MockTurtle {
+ public:
+
+  MOCK_METHOD0(PenUp, void());
+  MOCK_METHOD0(PenDown, void());
+  MOCK_METHOD1(Forward, void(int distance));
+  MOCK_CONST_METHOD0(GetY, int());
+};
+
+using ::testing::AtLeast;
+
 TEST(SampleTest, AssertionTrue) {
+    MockTurtle turtle;
+    EXPECT_CALL(turtle, PenDown())
+        .Times(AtLeast(1));
+
+    turtle.PenDown();
     ASSERT_EQ(1, 1);
 }
 

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -1,0 +1,10 @@
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+int main(int argc, char** argv) {
+  // The following line must be executed to initialize Google Mock
+  // (and Google Test) before running the tests.
+  ::testing::InitGoogleMock(&argc, argv);
+  return RUN_ALL_TESTS();
+}
+


### PR DESCRIPTION
From the googlemock wiki: 
„...With Google Mock, you can create mocks in C++ easily. ... 

When you write a test without using mocks, you exercise the code and assert that it returns the correct value or that the system is in an expected state. This is sometimes called "state-based testing". 

Mocks are great for what some call "interaction-based" testing: instead of checking the system state at the very end, mock objects verify that they are invoked the right way and report an error as soon as it arises, giving you a handle on the precise context in which the error was triggered. This is often more effective and economical to do than state-based testing…."

An example for vzlogger could be:
test the behavior of class MeterMap but using mocks for the Meter and Channel that e.g. can easily simulate errors on open(),… check whether all enabled ones are started but disabled one are not started,… (so basically checking the interface between two/multiple classes).

Replaces #60.
