### PR TITLE
added config timeout_s_read and delay_ms_baudrate_change for MeterD0

### DIFF
--- a/etc/vzlogger.conf
+++ b/etc/vzlogger.conf
@@ -62,8 +62,8 @@
             "protocol": "d0",               // see 'vzlogger -h' for list of available protocols
             "device": "/dev/ttyUSB0",
             "dump_file": "/var/log/dumpD0.txt", // optional, if set logs all received/transmitted data to this file
-//          "timeout_s_read": 10 // optional, default 10s. Timeout value in secs between single bytes received from device
-//          "delay_ms_baudrate_change": 400 // optional, default none. Delay value in ms after ACKSEQ send before baudrate change
+//          "timeout_s_read": 10, // optional, default 10s. Timeout value in secs between single bytes received from device
+//          "delay_ms_baudrate_change": 400, // optional, default none. Delay value in ms after ACKSEQ send before baudrate change
             "parity": "7E1",                // oder 8N1
             "baudrate": 9600,               // oder 300
 //          "pullseq": "2F3F210D0A",        // Pullsequenz in 'hex'

--- a/etc/vzlogger.conf
+++ b/etc/vzlogger.conf
@@ -62,6 +62,8 @@
             "protocol": "d0",               // see 'vzlogger -h' for list of available protocols
             "device": "/dev/ttyUSB0",
             "dump_file": "/var/log/dumpD0.txt", // optional, if set logs all received/transmitted data to this file
+//          "timeout_s_read": 10 // optional, default 10s. Timeout value in secs between single bytes received from device
+//          "delay_ms_baudrate_change": 400 // optional, default none. Delay value in ms after ACKSEQ send before baudrate change
             "parity": "7E1",                // oder 8N1
             "baudrate": 9600,               // oder 300
 //          "pullseq": "2F3F210D0A",        // Pullsequenz in 'hex'

--- a/etc/vzlogger.conf
+++ b/etc/vzlogger.conf
@@ -62,8 +62,8 @@
             "protocol": "d0",               // see 'vzlogger -h' for list of available protocols
             "device": "/dev/ttyUSB0",
             "dump_file": "/var/log/dumpD0.txt", // optional, if set logs all received/transmitted data to this file
-//          "timeout_s_read": 10, // optional, default 10s. Timeout value in secs between single bytes received from device
-//          "delay_ms_baudrate_change": 400, // optional, default none. Delay value in ms after ACKSEQ send before baudrate change
+//          "read_timeout": 10, // optional, default 10s. Timeout value in secs between single bytes received from device
+//          "baudrate_change_delay": 400, // optional, default none. Delay value in ms after ACKSEQ send before baudrate change
             "parity": "7E1",                // oder 8N1
             "baudrate": 9600,               // oder 300
 //          "pullseq": "2F3F210D0A",        // Pullsequenz in 'hex'

--- a/include/protocols/MeterD0.hpp
+++ b/include/protocols/MeterD0.hpp
@@ -57,7 +57,9 @@ private:
 	parity_type_t _parity;
 	std::string _pull;
 	std::string _ack;
-    bool _wait_sync_end;
+	bool _wait_sync_end;
+	int _timeout_s_read;
+	int _delay_ms_baudrate_change;
 
 
 	int _fd; /* file descriptor of port */

--- a/include/protocols/MeterD0.hpp
+++ b/include/protocols/MeterD0.hpp
@@ -60,7 +60,7 @@ private:
 	bool _wait_sync_end;
 	int _read_timeout_s;
 	int _baudrate_change_delay_ms;
-
+	int _reaction_time_ms; // reaction time t_r according to 62056-21
 
 	int _fd; /* file descriptor of port */
 	FILE *_dump_fd;

--- a/include/protocols/MeterD0.hpp
+++ b/include/protocols/MeterD0.hpp
@@ -58,8 +58,8 @@ private:
 	std::string _pull;
 	std::string _ack;
 	bool _wait_sync_end;
-	int _timeout_s_read;
-	int _delay_ms_baudrate_change;
+	int _read_timeout_s;
+	int _baudrate_change_delay_ms;
 
 
 	int _fd; /* file descriptor of port */

--- a/src/protocols/MeterD0.cpp
+++ b/src/protocols/MeterD0.cpp
@@ -822,7 +822,7 @@ void MeterD0::dump_file(DUMP_MODE mode, const char* buf, size_t len)
 		}
 	
 		fwrite(ctrl_end, 1, strlen(ctrl_end), _dump_fd);
-		const char *s, *e;
+		const char *s=0, *e=0;
 		switch (mode) {
 			case CTRL: s = ctrl_start; e = 0; break;
 			case DUMP_IN: s = dump_in_start; e = ctrl_end; break;

--- a/src/protocols/MeterD0.cpp
+++ b/src/protocols/MeterD0.cpp
@@ -36,6 +36,7 @@
 #include <unistd.h>
 #include <errno.h>
 #include <ctype.h>
+#include <time.h>
 #include <sys/time.h>
 
 // socket
@@ -54,6 +55,7 @@ MeterD0::MeterD0(std::list<Option> options)
 		, _wait_sync_end (false)
 		, _read_timeout_s (10)
 		, _baudrate_change_delay_ms (0)
+		, _reaction_time_ms (200) // default to 200ms
 		, _dump_fd(0)
 		, _old_mode(NONE)
 		, _dump_pos(0)
@@ -428,6 +430,12 @@ ssize_t MeterD0::read(std::vector<Reading>& rds, size_t max_readings) {
 				if (!isalpha(byte)) goto error;				// Vendor ID needs to be alpha
 				vendor[byte_iterator++] = byte;				// read next byte
 				if (byte_iterator >= VENDOR_LEN) {					// after 3rd byte
+					// check for reaction time indicator: (3rd letter lower case)
+					if (islower(vendor[2]))
+						_reaction_time_ms = 20; // lower case indicates 20ms
+					else
+						_reaction_time_ms = 200; // upper case indicates 200ms
+
 					vendor[byte_iterator] = '\0';			// termination
 					byte_iterator = 0;						// reset byte counter
 					context = BAUDRATE;						// set new context: VENDOR -> BAUDRATE
@@ -447,6 +455,7 @@ ssize_t MeterD0::read(std::vector<Reading>& rds, size_t max_readings) {
 							name().c_str(),  vendor, baudrate, identification);
 					byte_iterator = 0;
 					context = ACK;							// set new context: IDENTIFICATION -> ACK (old: OBIS_CODE)
+					// warning we send the ACK only after receiving of next char. This works only as the ID is ended by \r \n
 				}
 				else {
 					if (!isprint(byte)) {
@@ -466,6 +475,9 @@ ssize_t MeterD0::read(std::vector<Reading>& rds, size_t max_readings) {
 
 			case ACK:
 				if (_ack.size()) {
+					// first delay according to min reaction time:
+					usleep (_reaction_time_ms * 1000 );
+
 					// we have to send the ack with the old baudrate and change after successfull transmission:
 					int wlen = write(_fd,_ack.c_str(),_ack.size());
 					dump_file(DUMP_OUT, _ack.c_str(), wlen);
@@ -791,8 +803,8 @@ void MeterD0::dump_file(DUMP_MODE mode, const char* buf, size_t len)
 	const char *ctrl_start="##### ";
 	const char *ctrl_end="\n";
 	
-	const char *dump_out_start= "<<<<<\n";
-	const char *dump_in_start=">>>>>\n";
+	const char *dump_out_start= "<<<<< ";
+	const char *dump_in_start=">>>>> ";
 
 	static char str_dump[3*16 + 2 + 18]; // we output 3 chars per byte plus whitespace plus the char itself, 16 chars max in one row
 
@@ -810,17 +822,37 @@ void MeterD0::dump_file(DUMP_MODE mode, const char* buf, size_t len)
 		}
 	
 		fwrite(ctrl_end, 1, strlen(ctrl_end), _dump_fd);
-		const char *s;
+		const char *s, *e;
 		switch (mode) {
-			case CTRL: s = ctrl_start; break;
-			case DUMP_IN: s = dump_in_start; break;
-			case DUMP_OUT: s = dump_out_start; break;
+			case CTRL: s = ctrl_start; e = 0; break;
+			case DUMP_IN: s = dump_in_start; e = ctrl_end; break;
+			case DUMP_OUT: s = dump_out_start; e = ctrl_end; break;
 			default: s = ctrl_start; break;
 		}
 		fwrite(s, 1, strlen(s), _dump_fd);
+		// output timestamp:
+		struct timespec ts;
+		if (!clock_gettime(CLOCK_MONOTONIC_RAW, &ts)){
+			static struct timespec ts_last={0,0};
+			long delta = (ts.tv_sec * 1000000000L) + ts.tv_nsec;
+			delta -= ts_last.tv_nsec;
+			delta -= ts_last.tv_sec * 1000000000L;
+			delta /= 1000000L; // change into ms
+			if (ts_last.tv_sec==0)delta=0;
+			ts_last = ts;
+			char tbuf[30];
+			int l = snprintf(tbuf, sizeof(tbuf), "%2ld.%.9lds (%6ld ms) ", ts.tv_sec % 100, ts.tv_nsec, delta );
+			fwrite(tbuf, 1, l, _dump_fd);
+		}
+		if (e)
+			fwrite(e, 1, strlen(e), _dump_fd);
 	}
 	switch(mode) {
-	case CTRL: fwrite(buf, 1, len, _dump_fd); break;
+	case CTRL:
+		{
+			fwrite(buf, 1, len, _dump_fd);
+		}
+		break;
 	case DUMP_IN:
 	case DUMP_OUT:
 	{

--- a/src/protocols/MeterD0.cpp
+++ b/src/protocols/MeterD0.cpp
@@ -52,6 +52,8 @@ MeterD0::MeterD0(std::list<Option> options)
 		, _host("")
 		, _device("")
 		, _wait_sync_end (false)
+		, _timeout_s_read (10)
+		, _delay_ms_baudrate_change (0)
 		, _dump_fd(0)
 		, _old_mode(NONE)
 		, _dump_pos(0)
@@ -221,6 +223,23 @@ MeterD0::MeterD0(std::list<Option> options)
 		throw;
 	}
 
+    try {
+        _timeout_s_read = optlist.lookup_int(options, "timeout_s_read");
+    } catch (vz::OptionNotFoundException &e){
+        // use default: 10s from constructor
+    } catch (vz::VZException &e){
+        print(log_error, "Fauled to parse timeout_s_read", name().c_str());
+        throw;
+    }
+
+    try {
+		_delay_ms_baudrate_change = optlist.lookup_int(options, "delay_ms_baudrate_change");
+    } catch (vz::OptionNotFoundException &e){
+        // use default: (disabled) from constructor
+    } catch (vz::VZException &e){
+		print(log_error, "Fauled to parse delay_ms_baudrate_change", name().c_str());
+        throw;
+    }
 
 }
 
@@ -356,8 +375,8 @@ ssize_t MeterD0::read(std::vector<Reading>& rds, size_t max_readings) {
 	while (1) {
 		// check for timeout
 		time(&end_time);
-		if (difftime(end_time, start_time) > 10) {
-			print(log_error, "nothing received for more than 10 seconds", name().c_str());
+		if (difftime(end_time, start_time) > _timeout_s_read) {
+			print(log_error, "nothing received for more than %d seconds", name().c_str(), _timeout_s_read);
 			dump_file(CTRL, "timeout!");
 			break;
 		}
@@ -449,15 +468,19 @@ ssize_t MeterD0::read(std::vector<Reading>& rds, size_t max_readings) {
 					// we have to send the ack with the old baudrate and change after successfull transmission:
 					int wlen = write(_fd,_ack.c_str(),_ack.size());
 					dump_file(DUMP_OUT, _ack.c_str(), wlen);
-					tcdrain(_fd); // Wait until sent
+					if (!_delay_ms_baudrate_change) tcdrain(_fd); // if no delay is defined we use tcdrain Wait until sent
 					print(log_debug, "Sending ack sequence send (len:%d is:%d,%s).",
 							name().c_str(),_ack.size(),wlen,_ack.c_str());
 
-					//usleep (500000); // let's hope that tcdrain works even with usb serial adapters. TODO make delay config option
+					if (_delay_ms_baudrate_change) usleep (_delay_ms_baudrate_change*1000);
 					if (baudrate_read != baudrate_connect) {
 						cfsetispeed(&tio, baudrate_read);
+						cfsetospeed(&tio, baudrate_read); // we set this as well. might not be needed but adapters might not support different speed setups.
 						tcsetattr(_fd, TCSADRAIN, &tio); // TCSADRAIN should not be needed (TCSANOW might be sufficient)
-						dump_file(CTRL, "cfsetispeed");
+						if (_delay_ms_baudrate_change)
+							dump_file(CTRL, "usleep cfsetispeed");
+						else
+							dump_file(CTRL, "tcdrain cfsetispeed");
 					}
 				}
 				context = OBIS_CODE;

--- a/src/protocols/MeterD0.cpp
+++ b/src/protocols/MeterD0.cpp
@@ -340,6 +340,7 @@ ssize_t MeterD0::read(std::vector<Reading>& rds, size_t max_readings) {
 		cfsetospeed(&tio, baudrate_connect);
 		// apply new configuration
 		tcsetattr(_fd, TCSANOW, &tio);
+		if (_delay_ms_baudrate_change) usleep (_delay_ms_baudrate_change*1000); // give some time for baudrate change to be applied
 		int wlen=write(_fd,_pull.c_str(),_pull.size());
 		dump_file(DUMP_OUT, _pull.c_str(), wlen >0 ? wlen : 0);
 		print(log_debug,"sending pullsequenz send (len:%d is:%d).",name().c_str(),_pull.size(),wlen);

--- a/tests/MeterD0.cpp
+++ b/tests/MeterD0.cpp
@@ -42,6 +42,7 @@ TEST(MeterD0, basic_dump_fd) {
 	options.push_back(Option("device", tempfilename));
 	options.push_back(Option("dump_file", (char*)dumpName.c_str()));
 	options.push_back(Option("pullseq", (char*) "4041424344"));
+	options.push_back(Option("ackseq", (char*) "063030300d0a"));
 	MeterD0 m(options);
 	ASSERT_EQ(0, mkfifo(tempfilename, S_IRUSR|S_IWUSR));
 	int fd = open(tempfilename, O_RDWR);
@@ -50,7 +51,7 @@ TEST(MeterD0, basic_dump_fd) {
 	std::vector<Reading> rds;
 	rds.resize(1);
 	// can't test for timeout here as the fdset... don't work for pipes. EXPECT_EQ(0, m.read(rds, 10)); // check for timeout
-	writes(fd, "/HAG5eHZ010C_EHZ1vA02\r\n");
+	writes(fd, "/HAg5eHZ010C_EHZ1vA02\r\n"); // small (HA)g to set reaction time to 20ms
 	writes(fd, "1-0:1.8.0*255(000001.2963)\r\n"); // works only with \r\n error (see ack handling)
 	writes(fd, "!\n");
 	EXPECT_EQ(1, m.read(rds, 1));


### PR DESCRIPTION
- added two new configurable timeouts/delays for MeterD0:
 - timeout_s_read: timeout between singles bytes read from device in seconds. Was fixed to 10s till now.
 - delay_ms_baudrate_change: delay in ms between ACKSEQ send and before baud rate change. Defaults to 0 in which case the previous (tcdrain) solution is used.
- ospeed and ispeed are now always set to same value as some adapters might have problems with different settings.