### PR TITLE
meterD0: added new option ackseq auto to calc ackseq automatically and set baud rate_read to max supported

### DIFF
--- a/etc/vzlogger.conf
+++ b/etc/vzlogger.conf
@@ -67,7 +67,7 @@
             "parity": "7E1",                // oder 8N1
             "baudrate": 9600,               // oder 300
 //          "pullseq": "2F3F210D0A",        // Pullsequenz in 'hex'
-//          "ackseq": "063030300d0a",       // Antwortsequenz auf Zählerantwort,063030300d0a = 300bd, 063035300d0a = 9600bd
+//          "ackseq": "063030300d0a",       // optional (default: no ack seq) can either be a hex coded sequence send as ack (e.g. 063035300d0a for mode C with 9600bd) or can be set "auto" to calc ackseq automatically and switch to max baudrate supported (baudrate_read will be ignored in that case) (Antwortsequenz auf Zählerantwort,063030300d0a = 300bd, 063035300d0a = 9600bd)
 //          "baudrate_read": 300,           // Baudratenumschaltung auf gewünschte Baudrate, abhängig von Zählerantwort
 //          "aggtime": 20,                  // in Sekunden
 //          "aggmode": "AVG",               // Mittelwert für Leistung, "MAX" für Zähler, "SUM" für Counter

--- a/include/protocols/MeterD0.hpp
+++ b/include/protocols/MeterD0.hpp
@@ -57,6 +57,7 @@ private:
 	parity_type_t _parity;
 	std::string _pull;
 	std::string _ack;
+	bool _auto_ack;
 	bool _wait_sync_end;
 	int _read_timeout_s;
 	int _baudrate_change_delay_ms;

--- a/src/protocols/MeterD0.cpp
+++ b/src/protocols/MeterD0.cpp
@@ -520,6 +520,7 @@ ssize_t MeterD0::read(std::vector<Reading>& rds, size_t max_readings) {
 							baudrate_read = 300;  // don't set c
 							break;
 						}
+						_baudrate_read = baudrate_read; // store in member variable as well overriding the option parameter
 						if (c!=0)
 							_ack[2] = c;
 					}


### PR DESCRIPTION
To ease setup and reduce errors during setup I added an "auto" option for ackseq/baudrate_read  (set ackseq to "auto" in vzlogger.conf).
If it's set the ackseq get's calculated automatically and baudrate_read is automatically set to the maximum supported baud rate from the metering device.
Should be used if:
- ackseq needs to be send
- pullseq is defined (should be standard /?!\r\n)
- baudrate is set to 300.
