### PR TITLE
first mock tests for MeterMap and threads.cpp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,6 +128,9 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
     endif()
 endif()
 
+# enable unit testing
+include(CTest)
+enable_testing()
 
 if(Subversion_FOUND AND ENABLE_GOOGLEMOCK)
   add_subdirectory(gmock)
@@ -137,9 +140,6 @@ else()
    message(WARNING "googletest based unit tests disabled due to missing subversion! Please install svn.")
   endif()
 endif()
-# enable unit testing
-include(CTest)
-enable_testing()
 if(Subversion_FOUND)
   add_test(vzlogger_unit_tests tests/vzlogger_unit_tests)
 endif()

--- a/include/Meter.hpp
+++ b/include/Meter.hpp
@@ -44,16 +44,16 @@ public:
 //	Meter(const Meter *mtr);
 	virtual ~Meter();
 
-	void open();
-	int close();
-	size_t read(std::vector<Reading> &rds, size_t n);
+	virtual void open();
+	virtual int close();
+	virtual size_t read(std::vector<Reading> &rds, size_t n);
 
 	// setter
 	void interval(const int i) { _interval = i; }
 
 	// getter
 	const char *name() const { return _name.c_str(); }
-	bool isEnabled() const { return _enable; }
+	virtual bool isEnabled() const { return _enable; }
 
 	meter_protocol_t protocolId() const { return _protocol_id; }
 	vz::protocol::Protocol::Ptr protocol() const { return _protocol; }

--- a/include/MeterMap.hpp
+++ b/include/MeterMap.hpp
@@ -53,9 +53,10 @@ public:
 	typedef std::vector<Channel::Ptr>::iterator iterator;
 	typedef std::vector<Channel::Ptr>::const_iterator const_iterator;
 
-	MeterMap(std::list<Option> options) : _meter(new Meter(options)){
+	MeterMap(const std::list<Option> &options) : _meter(new Meter(options)){
 		_thread_running = false;
 	}
+	MeterMap(Meter *m) : _meter(m), _thread_running(false) {};
 	~MeterMap() {};
 	Meter::Ptr meter() { return _meter; }
 

--- a/include/Options.hpp
+++ b/include/Options.hpp
@@ -18,7 +18,7 @@ public:
 	} type_t;
 
 	Option(const char *key, struct json_object *jso);
-	Option(const char *key, char *value);
+	Option(const char *key, const char *value);
 	Option(const char *key, int value);
 	Option(const char *key, double value);
 	Option(const char *key, bool value);

--- a/src/Buffer.cpp
+++ b/src/Buffer.cpp
@@ -206,7 +206,7 @@ char * Buffer::dump(char *dump, size_t len) {
 	if (pos+1 < len) {
 		dump[pos++] = '}';
 		dump[pos] = '\0'; /* zero terminated string */
-	}
+	} else { unlock(); return NULL; } // otherwise unterminated string
 	unlock();
 
 	return (pos < len) ? dump : NULL; /* buffer full? */

--- a/src/MeterMap.cpp
+++ b/src/MeterMap.cpp
@@ -40,6 +40,7 @@
 #include <api/Volkszaehler.hpp>
 #include <api/MySmartGrid.hpp>
 #include <api/Null.hpp>
+#include "threads.h"
 
 extern Config_Options options;	/* global application options */
 
@@ -94,6 +95,7 @@ bool MeterMap::stopped() {
 				(*it)->cancel();
 				(*it)->join();
 			}
+			_meter->close();
 			return true;
 		}
 	}
@@ -109,7 +111,7 @@ void MeterMap::cancel() {
 		pthread_cancel(_thread);
 		pthread_join(_thread, NULL);
 		_thread_running = false;
-
+		_meter->close();
 		//_channels.clear();
 	}
 }

--- a/src/Options.cpp
+++ b/src/Options.cpp
@@ -53,7 +53,7 @@ Option::Option(const char *pKey, struct json_object *jso)
 	_type = (type_t)json_object_get_type(jso);
 }
 
-Option::Option(const char *pKey, char *pValue)
+Option::Option(const char *pKey, const char *pValue)
 		: _key(pKey)
 		, _type(type_string)
 		, _value_string(pValue)

--- a/src/api/MySmartGrid.cpp
+++ b/src/api/MySmartGrid.cpp
@@ -173,6 +173,7 @@ void vz::api::MySmartGrid::send()
 	json_str = json_object_to_json_string(json_obj);
 	if (json_str == NULL || strcmp(json_str, "null")==0) {
 		print(log_debug, "JSON request body is null. Nothing to send now.", channel()->name());
+		json_object_put(json_obj); // TODO untested!
 		return;
 	}
 

--- a/src/api/Volkszaehler.cpp
+++ b/src/api/Volkszaehler.cpp
@@ -164,7 +164,6 @@ void vz::api::Volkszaehler::register_device() {
 
 json_object * vz::api::Volkszaehler::api_json_tuples(Buffer::Ptr buf) {
 
-	json_object *json_tuples = json_object_new_array();
 	Buffer::iterator it;
 
 	print(log_debug, "==> number of tuples: %d", channel()->name(), buf->size());
@@ -188,6 +187,7 @@ json_object * vz::api::Volkszaehler::api_json_tuples(Buffer::Ptr buf) {
 		return NULL;
 	}
 
+	json_object *json_tuples = json_object_new_array();
 	for (it = _values.begin(); it != _values.end(); it++) {
 		struct json_object *json_tuple = json_object_new_array();
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -23,3 +23,5 @@ target_link_libraries(vzlogger_unit_tests ${CURL_STATIC_LIBRARIES} ${CURL_LIBRAR
 if(SML_FOUND)
   target_link_libraries(vzlogger_unit_tests ${SML_LIBRARY})
 endif(SML_FOUND)
+
+add_subdirectory(mocks)

--- a/tests/mocks/CMakeLists.txt
+++ b/tests/mocks/CMakeLists.txt
@@ -1,0 +1,40 @@
+include_directories(BEFORE .)
+
+add_executable(mock_metermap mock_metermap.cpp ../../src/Meter.cpp ../../src/Options.cpp
+	../../src/protocols/MeterD0.cpp
+	../../src/protocols/MeterFile.cpp
+	../../src/protocols/MeterExec.cpp
+	../../src/protocols/MeterS0.cpp
+	../../src/protocols/MeterRandom.cpp
+	../../src/protocols/MeterSML.cpp
+	../../src/protocols/MeterFluksoV2.cpp
+	../../src/Reading.cpp
+	../../src/Obis.cpp
+	../../src/ltqnorm.cpp
+	../../src/MeterMap.cpp
+	../../src/threads.cpp
+	../../src/Config_Options.cpp
+	../../src/Buffer.cpp
+	../../src/api/Volkszaehler.cpp
+	../../src/api/MySmartGrid.cpp
+	../../src/api/Null.cpp
+	../../src/api/CurlIF.cpp
+	../../src/api/CurlCallback.cpp
+	../../src/api/CurlResponse.cpp
+)
+target_link_libraries(mock_metermap ${CURL_STATIC_LIBRARIES} ${CURL_LIBRARIES} ${GNUTLS_LIBRARIES} ${OPENSSL_LIBRARIES})
+
+target_link_libraries(mock_metermap 
+		${GTEST_LIBS_DIR}/libgtest.a
+		${GMOCK_LIBS_DIR}/libgmock.a
+		pthread
+		${JSON_LIBRARY}
+		${LIBUUID}
+		dl
+	  )
+if(SML_FOUND)
+  target_link_libraries(mock_metermap ${SML_LIBRARY})
+endif(SML_FOUND)
+
+
+add_test(mock_metermap mock_metermap)

--- a/tests/mocks/Channel.hpp
+++ b/tests/mocks/Channel.hpp
@@ -1,0 +1,41 @@
+#ifndef _CHANNEL_H_
+#define _CHANNEL_H_
+
+#include <gmock/gmock.h>
+
+
+#include "Options.hpp"
+#include "Reading.hpp"
+#include "Buffer.hpp"
+
+class Channel
+{
+public:
+	typedef vz::shared_ptr<Channel> Ptr;
+	Channel() : mock_buf(new Buffer()){};
+	Channel(const std::list<Option> &pOptions, const std::string api, const std::string pUuid, ReadingIdentifier::Ptr pIdentifier) : mock_buf(new Buffer()){};
+	MOCK_METHOD0( start, void());
+	MOCK_METHOD0( join, void());
+	MOCK_METHOD0( cancel, void());
+	MOCK_METHOD0( name,	const char* ());
+	MOCK_METHOD0( options, std::list<Option> &());
+	MOCK_METHOD0( apiProtocol, const std::string());
+	MOCK_METHOD0( buffer, Buffer::Ptr());
+	MOCK_METHOD0( identifier, ReadingIdentifier::Ptr());
+	MOCK_CONST_METHOD0( tvtod, double ());
+	MOCK_METHOD1( last, void (Reading *rd));
+	MOCK_METHOD1( push, void (const Reading &rd));
+	MOCK_METHOD0( notify, void ());
+	MOCK_METHOD2( dump, char* (char *dump, size_t len));
+	MOCK_CONST_METHOD0( size, size_t ());
+	MOCK_CONST_METHOD0( keep, size_t ());
+	MOCK_METHOD0( wait, void ());
+	MOCK_METHOD0( uuid, const char* ());
+
+	ReadingIdentifier::Ptr &real_id() {return mock_id;}
+	ReadingIdentifier::Ptr mock_id;
+	Buffer::Ptr mock_buf;
+	Buffer::Ptr &real_buf() {return mock_buf;}
+};
+
+#endif

--- a/tests/mocks/mock_metermap.cpp
+++ b/tests/mocks/mock_metermap.cpp
@@ -1,0 +1,185 @@
+#include <gmock/gmock.h>
+  using ::testing::Eq;
+  using ::testing::Return;
+  using ::testing::InSequence;
+  using ::testing::AtLeast;
+  using ::testing::Invoke;
+  using ::testing::Ge;
+  using ::testing::_;
+  using ::testing::SetArrayArgument;
+
+#include <gtest/gtest.h>
+  using ::testing::Test;
+
+#include "Channel.hpp"
+#include "Meter.hpp"
+#include "MeterMap.hpp"
+#include "Config_Options.hpp"
+
+namespace mock_metermap
+{
+
+class mock_meter : public Meter
+{
+public:
+	mock_meter(const std::list<Option> &o) : Meter(o){};
+	virtual ~mock_meter(){};
+//    mock_meter() : Meter(std::list<Option>()) {};
+	MOCK_METHOD0(open, void());
+	MOCK_METHOD0(close, int());
+	MOCK_CONST_METHOD0(isEnabled, bool());
+	MOCK_METHOD2( read, size_t (std::vector<Reading> &rds, size_t n));
+
+};
+
+
+// here we test class MeterMap and threads.cpp:
+// we mock the other classes used
+
+TEST(mock_metermap, basic_open_close_enabled)
+{
+	std::list<Option> o;
+	o.push_back(Option("protocol", "random"));
+	mock_meter *mtr=new mock_meter(o);
+	mtr->interval(1);
+	EXPECT_CALL(*mtr, isEnabled()).Times(AtLeast(1)).WillRepeatedly(Return(true));
+	{
+		InSequence d;
+		EXPECT_CALL(*mtr, open()).Times(1);
+		EXPECT_CALL(*mtr, close()); // Times(1) assumed
+
+	}
+
+	MeterMap m (mtr);
+	m.start();
+	m.cancel();
+	EXPECT_FALSE(m.stopped()); // TODO this looks like a bug!
+}
+
+
+// test that disabled meters don't get open/closed
+
+TEST(mock_metermap, basic_open_close_not_enabled)
+{
+	std::list<Option> o;
+	o.push_back(Option("protocol", "random"));
+	mock_meter *mtr=new mock_meter(o);
+	mtr->interval(1);
+	EXPECT_CALL(*mtr, isEnabled()).Times(AtLeast(1));
+	EXPECT_CALL(*mtr, open()).Times(0);
+	EXPECT_CALL(*mtr, close()).Times(0);
+
+	MeterMap m (mtr);
+	m.start();
+	m.cancel();
+	EXPECT_FALSE(m.stopped()); // TODO this looks like a bug!
+}
+
+TEST(mock_metermap, one_channel)
+{
+	std::list<Option> o;
+	o.push_back(Option("protocol", "random"));
+	mock_meter *mtr=new mock_meter(o);
+	mtr->interval(1);
+	EXPECT_CALL(*mtr, isEnabled()).Times(AtLeast(1)).WillRepeatedly(Return(true));
+	{
+		InSequence d;
+		EXPECT_CALL(*mtr, open()).Times(1);
+		EXPECT_CALL(*mtr, close()); // Times(1) assumed
+
+	}
+
+	MeterMap m (mtr);
+	Channel *ch = new Channel();
+	EXPECT_CALL(*ch, name()).Times(AtLeast(1));
+	EXPECT_CALL(*ch, identifier()).Times(AtLeast(1)).WillRepeatedly(Return(ReadingIdentifier::Ptr()));
+	EXPECT_CALL(*ch, buffer()).Times(AtLeast(1)).WillRepeatedly(Invoke(ch, &Channel::real_buf));
+	EXPECT_CALL(*ch, notify()).Times(AtLeast(0)); // can be called 0 or sometimes
+	{
+		InSequence s;
+		EXPECT_CALL(*ch, start()).Times(1);
+		EXPECT_CALL(*ch, cancel()).Times(1);
+		EXPECT_CALL(*ch, join()).Times(1);
+	}
+	// TODO Bug? Channel::Notify get's called even without a single reading gathered!
+	m.push_back(Channel::Ptr(ch));
+	EXPECT_CALL(*mtr, read(_, Ge(1u))).Times(AtLeast(1)).WillRepeatedly(Return (1));
+
+	m.start();
+	usleep(100000); // give reading thread a chance. todo better cancel that synchronizes with readingthread
+	m.cancel();
+	EXPECT_FALSE(m.stopped()); // TODO this looks like a bug!
+}
+
+// test whether the read data get's only into the proper channels: (two channel can have same id)
+size_t return_read(std::vector<Reading> &rds, size_t n)
+{
+	if (n>0)
+		rds[0] = Reading(ReadingIdentifier::Ptr(new ChannelIdentifier(1)));
+	return 1;
+}
+
+
+TEST(mock_metermap, reading_in_proper_channel)
+{
+	std::list<Option> o;
+	o.push_back((Option("protocol", "random")));
+	mock_meter *mtr = new mock_meter(o);
+	EXPECT_CALL(*mtr, isEnabled()).Times(AtLeast(1)).WillRepeatedly(Return(true));
+
+	MeterMap m(mtr);
+	mtr->interval(1);
+	Channel *ch1 = new Channel();
+	Channel *ch2 = new Channel();
+	Channel *ch3 = new Channel();
+
+	// assign ids: 1 2 1 (so ch1.id == ch3.id)
+	EXPECT_CALL(*ch1, identifier()).Times(AtLeast(1)).WillRepeatedly(Return(ReadingIdentifier::Ptr(new ChannelIdentifier(1))));
+	EXPECT_CALL(*ch2, identifier()).Times(AtLeast(1)).WillRepeatedly(Return(ReadingIdentifier::Ptr(new ChannelIdentifier(2))));
+	EXPECT_CALL(*ch3, identifier()).Times(AtLeast(1)).WillRepeatedly(Return(ReadingIdentifier::Ptr(new ChannelIdentifier(1))));
+
+	// make sure the channels have a real buffer:
+	EXPECT_CALL(*ch1, buffer()).Times(AtLeast(1)).WillRepeatedly(Invoke(ch1, &Channel::real_buf));
+	EXPECT_CALL(*ch2, buffer()).Times(AtLeast(1)).WillRepeatedly(Invoke(ch2, &Channel::real_buf));
+	EXPECT_CALL(*ch3, buffer()).Times(AtLeast(1)).WillRepeatedly(Invoke(ch3, &Channel::real_buf));
+
+	// our test. Make sure that ch1 and ch3 get one reading and ch2 gets none
+	EXPECT_CALL(*ch1, push(_)).Times(1);
+	EXPECT_CALL(*ch2, push(_)).Times(0);
+	EXPECT_CALL(*ch3, push(_)).Times(1);
+
+	EXPECT_CALL(*mtr, read(_, Ge(1u))).Times(AtLeast(1)).
+			WillRepeatedly(Invoke(return_read));
+
+	m.push_back(Channel::Ptr(ch1));
+	m.push_back(Channel::Ptr(ch2));
+	m.push_back(Channel::Ptr(ch3));
+	m.start();
+	usleep(100000);
+	m.cancel();
+
+}
+
+}
+
+Config_Options options;
+
+void print(log_level_t l, char const*s1, char const*s2, ...)
+{
+//	if (l!= log_debug)
+	{
+		fprintf(stdout, "\n  %s:", s2);
+		va_list argp;
+		va_start(argp, s2);
+		vfprintf(stdout, s1, argp);
+		va_end(argp);
+		fprintf(stdout, "\n");
+	}
+}
+
+int main(int argc, char** argv) {
+  // The following line must be executed to initialize Google Mock
+  // (and Google Test) before running the tests.
+  ::testing::InitGoogleMock(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
After the introduction of googlemock into the source tree see here the first examples of some unit tests using mocked interfaces.

I fixed some memory leaks as well and made some functions virtual to enable partial mocked interfaces. The first test highlighted some problems e.g. like meter->close() never being called (fixed that as well).