### PR TITLE
Fix local http returning data tuples (see #79)

### DIFF
--- a/etc/vzlogger.conf
+++ b/etc/vzlogger.conf
@@ -18,7 +18,7 @@
         "port": 8080,       // the TCP port for the local HTTPd
         "index": true,      // should we provide a index listing of available channels if no UUID was requested?
         "timeout": 30,      // timeout for long polling comet requests, 0 disables comet, in seconds
-        "buffer": 600       // how long to buffer readings for the local interface, in seconds
+        "buffer": -1       // how long to buffer readings for the local interface, in seconds (if greater 0) or how many tuples to return per channel if <0 (-3 = return 3 tuples), default -1
     },
 
     "meters": [

--- a/include/Buffer.hpp
+++ b/include/Buffer.hpp
@@ -60,9 +60,6 @@ class Buffer {
 	inline bool newValues() const { return _newValues; }
 	inline void clear_newValues() { _newValues = false; }
 
-	inline size_t keep() const { return _keep; }
-	inline void keep(const size_t keep) { _keep = keep; }
-
 	inline void lock()   { pthread_mutex_lock(&_mutex); }
 	inline void unlock() { pthread_mutex_unlock(&_mutex); }
 	inline void wait(pthread_cond_t *condition) { pthread_cond_wait(condition, &_mutex); }

--- a/include/Channel.hpp
+++ b/include/Channel.hpp
@@ -64,7 +64,7 @@ class Channel {
 		if (_identifier.use_count() < 1) throw vz::VZException("Not identifier defined.") ; return _identifier; }
 	double tvtod() const          { return _last == NULL ? 0 : _last->tvtod(); }
 
-	const char* uuid()                  { return _uuid.c_str(); }
+	const char* uuid() const            { return _uuid.c_str(); }
 	const std::string apiProtocol()     { return _apiProtocol; }
 
 	void last(Reading *rd)              { _last = rd;}
@@ -73,7 +73,6 @@ class Channel {
 	Buffer::Ptr buffer()                { return _buffer; }
 
 	size_t size() const { return _buffer->size(); }
-	size_t keep() const { return _buffer->keep(); }
 
 	inline void notify() {
 		_buffer->lock();

--- a/include/local.h
+++ b/include/local.h
@@ -43,6 +43,10 @@ int handle_request(
 	void **con_cls
 );
 
+class Channel;
+void shrink_localbuffer(); // remove old data in the local buffer
+void add_ch_to_localbuffer(Channel &ch);
+
 #endif /* _LOCAL_H_ */
 
 

--- a/src/Buffer.cpp
+++ b/src/Buffer.cpp
@@ -171,17 +171,6 @@ void Buffer::undelete() {
 	unlock();
 }
 
-
-void Buffer::shrink(/*size_t keep*/) {
-	lock();
-
-//	while(size > keep && begin() != sent) {
-//		pop();
-//	}
-
-	unlock();
-}
-
 char * Buffer::dump(char *dump, size_t len) {
 	size_t pos = 0;
 	dump[pos++] = '{';

--- a/src/Config_Options.cpp
+++ b/src/Config_Options.cpp
@@ -40,7 +40,7 @@ Config_Options::Config_Options()
 		, _port(8080)
 		, _verbosity(0)
 		, _comet_timeout(30)
-		, _buffer_length(600)
+		, _buffer_length(-1)
 		, _retry_pause(15)
 		, _daemon(false)
 		, _local(false)
@@ -57,7 +57,7 @@ Config_Options::Config_Options(
 		, _port(8080)
 		, _verbosity(0)
 		, _comet_timeout(30)
-		, _buffer_length(600)
+		, _buffer_length(-1)
 		, _retry_pause(15)
 		, _daemon(false)
 		, _local(false)
@@ -140,6 +140,7 @@ void Config_Options::config_parse(
 					}
 					else if (strcmp(key, "buffer") == 0 && local_type == json_type_int) {
 						_buffer_length = json_object_get_int(local_value);
+						if (!_buffer_length) _buffer_length = -1; // 0 makes no sense, use size based mode with 1 element
 					}
 					else if (strcmp(key, "index") == 0 && local_type == json_type_boolean) {
 						_channel_index = json_object_get_boolean(local_value);

--- a/src/MeterMap.cpp
+++ b/src/MeterMap.cpp
@@ -68,10 +68,6 @@ void MeterMap::start() {
 
 		print(log_debug, "Meter is opened. Starting channels.", _meter->name());
 		for (iterator it = _channels.begin(); it!=_channels.end(); it++) {
-			// set buffer length for perriodic meters
-			if (meter_get_details(_meter->protocolId())->periodic && options.local()) {
-				(*it)->buffer()->keep(ceil(options.buffer_length() / (double) _meter->interval()));
-			}
 
 			if (options.logging()) {
 				(*it)->start();

--- a/tests/mocks/CMakeLists.txt
+++ b/tests/mocks/CMakeLists.txt
@@ -22,8 +22,9 @@ add_executable(mock_metermap mock_metermap.cpp ../../src/Meter.cpp ../../src/Opt
 	../../src/api/CurlCallback.cpp
 	../../src/api/CurlResponse.cpp
 	../../src/CurlSessionProvider.cpp
+	../../src/local.cpp
 )
-target_link_libraries(mock_metermap ${CURL_STATIC_LIBRARIES} ${CURL_LIBRARIES} ${GNUTLS_LIBRARIES} ${OPENSSL_LIBRARIES})
+target_link_libraries(mock_metermap ${CURL_STATIC_LIBRARIES} ${CURL_LIBRARIES} ${MICROHTTPD_LIBRARY} ${GNUTLS_LIBRARIES} ${OPENSSL_LIBRARIES})
 
 target_link_libraries(mock_metermap 
 		${GTEST_LIBS_DIR}/libgtest.a

--- a/tests/mocks/Channel.hpp
+++ b/tests/mocks/Channel.hpp
@@ -28,7 +28,6 @@ public:
 	MOCK_METHOD0( notify, void ());
 	MOCK_METHOD2( dump, char* (char *dump, size_t len));
 	MOCK_CONST_METHOD0( size, size_t ());
-	MOCK_CONST_METHOD0( keep, size_t ());
 	MOCK_METHOD0( wait, void ());
 	MOCK_METHOD0( uuid, const char* ());
 


### PR DESCRIPTION
Fix for #79.
Added change to return int64 truncated to ms as timestamp.
(Not done yet for api/volkszaehler to keep this PR restricted to local httpd fix.)