### PR TITLE
implemented duplicate handling for volkszaehler api (see #98)

### DIFF
--- a/etc/vzlogger.conf
+++ b/etc/vzlogger.conf
@@ -35,7 +35,8 @@
             }, {
                 "uuid": "a8da012a-9eb4-49ed-b7f3-38c95142a90c",
                 "middleware": "http://localhost/middleware.php",
-                "identifier": "counter"
+                "identifier": "counter",
+                "duplicates": 10 // default 0 (send duplicate values), >0 = send duplicate values only each <duplicates> seconds. Before value change send last ignored value to keep waveform.
             }, {
                 "uuid": "d5c6db0f-533e-498d-a85a-be972c104b48",
                 "middleware": "http://localhost/middleware.php",

--- a/include/Channel.hpp
+++ b/include/Channel.hpp
@@ -88,6 +88,8 @@ class Channel {
 		_buffer->unlock();
 	}
 
+	int duplicates() const { return _duplicates; }
+
 	private:
 	static int instances;
 	bool _thread_running;   	// flag if thread is started
@@ -106,6 +108,7 @@ class Channel {
 
 	std::string _uuid;			// unique identifier for middleware
 	std::string _apiProtocol;	// protocol of api to use for logging
+	int _duplicates;			// how to handle duplicate values (see conf)
 };
 
 #endif /* _CHANNEL_H_ */

--- a/include/Reading.hpp
+++ b/include/Reading.hpp
@@ -167,6 +167,9 @@ public:
  */
     size_t unparse(/*meter_protocol_t protocol,*/ char *buffer, size_t n);
 
+    bool operator==(const Reading &rhs) const {return (_deleted == rhs._deleted) && (_value == rhs._value) &&
+                (_time.tv_sec == rhs._time.tv_sec) && (_time.tv_usec == rhs._time.tv_usec);}
+
 protected:
 	bool   _deleted;
 	double _value;

--- a/include/api/Volkszaehler.hpp
+++ b/include/api/Volkszaehler.hpp
@@ -76,8 +76,6 @@ namespace vz {
 			 * Create JSON object of tuples
 			 *
 			 * @param buf	the buffer our readings are stored in (required for mutex)
-			 * @param first	the first tuple of our linked list which should be encoded
-			 * @param last	the last tuple of our linked list which should be encoded
 			 * @return the json_object (has to be free'd)
 			 */
 			json_object * api_json_tuples(Buffer::Ptr buf);
@@ -95,6 +93,9 @@ namespace vz {
           // Volatil
 			std::list<Reading> _values;
           uint64_t _last_timestamp; /**< remember last timestamp */
+          // duplicate support:
+          Reading *_lastReadingSent;
+          Reading *_lastReadingIgnored;
 
 		}; //class Volkszaehler
 

--- a/src/Channel.cpp
+++ b/src/Channel.cpp
@@ -49,6 +49,7 @@ Channel::Channel(
 		, _last(0)
 		, _uuid(uuid)
 		, _apiProtocol(apiProtocol)
+		, _duplicates (0)
 {
 	id = instances++;
 
@@ -60,7 +61,7 @@ Channel::Channel(
 	OptionList optlist;
 
 	try {
-		/* aggmode */
+		// aggmode
 		const char *aggmode_str = optlist.lookup_string(pOptions, "aggmode");
 		if (strcasecmp(aggmode_str, "max") == 0 ) {
 			_buffer->set_aggmode(Buffer::MAX);
@@ -74,7 +75,7 @@ Channel::Channel(
 			throw vz::VZException("Aggmode unknown.");
 		}
 	} catch (vz::OptionNotFoundException &e) {
-		/* using default value if not specified */
+		// using default value if not specified
 		_buffer->set_aggmode(Buffer::NONE);
 	} catch (vz::VZException &e) {
 		std::stringstream oss;
@@ -83,9 +84,19 @@ Channel::Channel(
 		throw;
 	}
 
+	try {
+		_duplicates = optlist.lookup_int(pOptions, "duplicates");
+		if (_duplicates < 0) throw vz::VZException("duplicates < 0 not allowed");
+	} catch (vz::OptionNotFoundException &e) {
+		// using default value if not specified (from above)
+	} catch (vz::VZException &e) {
+		std::stringstream oss;
+		oss << e.what();
+		print(log_error, "Invalid parameter duplicates (%s)", name(), oss.str().c_str());
+		throw;
+	}
 
-
-	pthread_cond_init(&condition, NULL); /* initialize thread syncronization helpers */
+	pthread_cond_init(&condition, NULL); // initialize thread syncronization helpers
 }
 
 /**

--- a/src/api/Volkszaehler.cpp
+++ b/src/api/Volkszaehler.cpp
@@ -206,7 +206,7 @@ json_object * vz::api::Volkszaehler::api_json_tuples(Buffer::Ptr buf) {
 				} else { // one reading sent already. compare
 					// a) timestamp
 					// b) duplicate value
-					if ((timestamp > (_last_timestamp + duplicates_ms)) ||
+					if ((timestamp >= (_last_timestamp + duplicates_ms)) ||
 							(r.value() != _lastReadingSent->value())) {
 						// send the last ignored first iff value changed:
 						if (_lastReadingIgnored) {

--- a/src/api/Volkszaehler.cpp
+++ b/src/api/Volkszaehler.cpp
@@ -48,6 +48,8 @@ vz::api::Volkszaehler::Volkszaehler(
 	)
 	: ApiIF(ch)
 	, _last_timestamp(0)
+	, _lastReadingSent (0)
+	, _lastReadingIgnored (0)
 {
 	OptionList optlist;
 	char agent[255];
@@ -85,6 +87,8 @@ vz::api::Volkszaehler::Volkszaehler(
 
 vz::api::Volkszaehler::~Volkszaehler()
 {
+	if (_lastReadingSent) delete _lastReadingSent;
+	if (_lastReadingIgnored) delete _lastReadingIgnored;
 }
 
 void vz::api::Volkszaehler::send()
@@ -175,15 +179,56 @@ json_object * vz::api::Volkszaehler::api_json_tuples(Buffer::Ptr buf) {
 
 	print(log_debug, "==> number of tuples: %d", channel()->name(), buf->size());
 	uint64_t timestamp = 1;
+	const int duplicates = channel()->duplicates();
+	const int duplicates_ms = duplicates * 1000;
 
 	// copy all values to local buffer queue
 	buf->lock();
 	for (it = buf->begin(); it != buf->end(); it++) {
-		timestamp = round(it->tvtod() * 1000);
+		timestamp = it->tvtod() * 1000; // round similar as timestamp send to middleware
 		print(log_debug, "compare: %llu %llu %f", channel()->name(), _last_timestamp, timestamp, it->tvtod() * 1000);
+		// we can only add/consider a timestamp if the ms resolution is different than from previous one:
 		if (_last_timestamp < timestamp ) {
-			_values.push_back(*it);
-			_last_timestamp = timestamp;
+			if (0 == duplicates) { // send all values
+				_values.push_back(*it);
+				_last_timestamp = timestamp;
+			} else {
+				const Reading &r = *it;
+				// duplicates should be ignored
+				// but send at least each <duplicates> seconds
+				// and if the value changes the last one ignored should be send as well (to keep the "waveform")
+
+				if (!_lastReadingSent) { // first one from the duplicate consideration -> send it
+					_lastReadingSent = new Reading(r);
+					_values.push_back(r);
+					_last_timestamp = timestamp;
+					if( _lastReadingIgnored != 0) print(log_error, "logical error! lastReadingIgnored !=0", channel()->name());
+				} else { // one reading sent already. compare
+					// a) timestamp
+					// b) duplicate value
+					if ((timestamp > (_last_timestamp + duplicates_ms)) ||
+							(r.value() != _lastReadingSent->value())) {
+						// send the last ignored first iff value changed:
+						if (_lastReadingIgnored) {
+							if (r.value() != _lastReadingSent->value()) {
+								_values.push_back(*_lastReadingIgnored);
+							}
+							delete _lastReadingIgnored;
+							_lastReadingIgnored = 0;
+						}
+						// send the current one:
+						_values.push_back(r);
+						_last_timestamp = timestamp;
+						*_lastReadingSent = r;
+					} else {
+						// ignore it:
+						if (!_lastReadingIgnored)
+							_lastReadingIgnored = new Reading(r);
+						else
+							*_lastReadingIgnored = r;
+					}
+				}
+			}
 		}
 		it->mark_delete();
 	}

--- a/tests/mocks/Channel.hpp
+++ b/tests/mocks/Channel.hpp
@@ -30,6 +30,7 @@ public:
 	MOCK_CONST_METHOD0( size, size_t ());
 	MOCK_METHOD0( wait, void ());
 	MOCK_METHOD0( uuid, const char* ());
+	MOCK_CONST_METHOD0( duplicates, int ());
 
 	ReadingIdentifier::Ptr &real_id() {return mock_id;}
 	ReadingIdentifier::Ptr mock_id;

--- a/tests/ut_api_volkszaehler.cpp
+++ b/tests/ut_api_volkszaehler.cpp
@@ -17,6 +17,7 @@ class Volkszaehler_Test
 		static void api_parse_exception(vz::api::Volkszaehler &v, vz::api::CURLresponse &r, 
 		char *&err, size_t &n){ v.api_parse_exception(r, err, n);} 
 		static std::list<Reading> &values(Volkszaehler &v) {return v._values;}
+		static json_object * api_json_tuples(Volkszaehler &v, Buffer::Ptr buf) { return v.api_json_tuples(buf);};
 };
 }
 }
@@ -97,3 +98,180 @@ using namespace vz::api;
 	delete [] err;
 }
 
+TEST(api_Volkszaehler, api_json_tuples_no_duplicates) {
+using namespace vz::api;
+	std::list<Option> options;
+	options.push_front(Option("middleware", (char*)"bla_middleware"));
+	ReadingIdentifier::Ptr pRid;
+	Channel *ch = new Channel(options, std::string("bla_api"), std::string("bla_uuid"), pRid);
+	Channel::Ptr chp(ch);
+	Volkszaehler v(chp, options);
+
+	// test using empty data:
+	json_object *j = Volkszaehler_Test::api_json_tuples(v, ch->buffer());
+	ASSERT_TRUE(j == 0);
+	ASSERT_TRUE(Volkszaehler_Test::values(v).size() == 0);
+
+	struct timeval t1;
+	t1.tv_sec = 1;
+	t1.tv_usec = 1;
+	struct timeval t2;
+	t2.tv_sec = 2;
+	t2.tv_usec = 1;
+	Reading r1(1.0, t1, pRid);
+	Reading r2(1.0, t2, pRid);
+	ch->push(r1);
+
+	// expect one data returned in values:
+	j = Volkszaehler_Test::api_json_tuples(v, ch->buffer());
+	ASSERT_TRUE(j != 0);
+	ASSERT_TRUE(Volkszaehler_Test::values(v).size() == 1);
+	ASSERT_EQ(Volkszaehler_Test::values(v).front(), r1);
+	json_object_put(j);
+	ch->buffer()->clean(); // remove deleted
+	ASSERT_TRUE( ch->buffer()->size() == 0);
+
+	ch->push(r1);
+	ch->push(r2);
+	// expect only two data returned in values: (r1 ignored as timestamp same as previous) and r2)
+	j = Volkszaehler_Test::api_json_tuples(v, ch->buffer());
+	ASSERT_TRUE(j != 0);
+	ASSERT_TRUE(Volkszaehler_Test::values(v).size() == 2);
+	ASSERT_EQ(Volkszaehler_Test::values(v).front(), r1);
+	ASSERT_EQ(Volkszaehler_Test::values(v).back(), r2);
+
+	json_object_put(j);
+	ch->buffer()->clean(); // remove deleted
+	ASSERT_TRUE( ch->buffer()->size() == 0);
+
+}
+
+TEST(api_Volkszaehler, api_json_tuples_duplicates) {
+using namespace vz::api;
+	std::list<Option> options;
+	options.push_front(Option("middleware", (char*)"bla_middleware"));
+	options.push_back(Option("duplicates", 10));
+	ReadingIdentifier::Ptr pRid;
+	Channel *ch = new Channel(options, std::string("bla_api"), std::string("bla_uuid"), pRid);
+	Channel::Ptr chp(ch);
+	Volkszaehler v(chp, options);
+
+	// test using empty data:
+	json_object *j = Volkszaehler_Test::api_json_tuples(v, ch->buffer());
+	ASSERT_TRUE(j == 0);
+	ASSERT_TRUE(Volkszaehler_Test::values(v).size() == 0);
+
+	struct timeval t1;
+	t1.tv_sec = 1;
+	t1.tv_usec = 1;
+	struct timeval t2;
+	t2.tv_sec = 2;
+	t2.tv_usec = 1;
+	Reading r1(1.0, t1, pRid);
+	Reading r2(1.0, t2, pRid);
+	ch->push(r1);
+
+	// expect one data returned in values:
+	j = Volkszaehler_Test::api_json_tuples(v, ch->buffer());
+	ASSERT_TRUE(j != 0);
+	ASSERT_TRUE(Volkszaehler_Test::values(v).size() == 1);
+	ASSERT_EQ(Volkszaehler_Test::values(v).front(), r1);
+	json_object_put(j);
+	ch->buffer()->clean(); // remove deleted
+	ASSERT_TRUE( ch->buffer()->size() == 0);
+
+	ch->push(r1);
+	ch->push(r2);
+	// expect one data returned in values: (r1 same timestamp, r2 ignored)
+	j = Volkszaehler_Test::api_json_tuples(v, ch->buffer());
+	ASSERT_TRUE(j != 0);
+	ASSERT_TRUE(Volkszaehler_Test::values(v).size() == 1);
+	ASSERT_EQ(Volkszaehler_Test::values(v).front(), r1);
+
+	json_object_put(j);
+	ch->buffer()->clean(); // remove deleted
+	ASSERT_TRUE( ch->buffer()->size() == 0);
+
+	struct timeval t3;
+	t3.tv_sec = 2;
+	t3.tv_usec = 1+1000; // at least one ms distance
+	Reading r3(2.0, t3, pRid);
+	ch->push(r3);
+
+	// now add one with a different value:
+	// then we should get r1, r2 and the new value r3:
+	j = Volkszaehler_Test::api_json_tuples(v, ch->buffer());
+	ASSERT_TRUE(j != 0);
+	ASSERT_TRUE(Volkszaehler_Test::values(v).size() == 3);
+	ASSERT_EQ(Volkszaehler_Test::values(v).front(), r1);
+	Volkszaehler_Test::values(v).pop_front();
+	ASSERT_EQ(Volkszaehler_Test::values(v).front(), r2);
+	Volkszaehler_Test::values(v).pop_front();
+	ASSERT_EQ(Volkszaehler_Test::values(v).front(), r3);
+
+	json_object_put(j);
+	ASSERT_TRUE( ch->buffer()->size() == 0);
+
+
+	// now try timeout:
+	// add r4 with same value but distance >10s
+	t1.tv_sec = t3.tv_sec + 10;
+	t1.tv_usec = t3.tv_usec;
+	Reading r4(2.0, t1, pRid);
+	ch->push(r4);
+	// now there should be r3 and r4:
+	j = Volkszaehler_Test::api_json_tuples(v, ch->buffer());
+	ASSERT_TRUE(j != 0);
+	ASSERT_TRUE(Volkszaehler_Test::values(v).size() == 2) << Volkszaehler_Test::values(v).size();
+	ASSERT_EQ(Volkszaehler_Test::values(v).front(), r3);
+	Volkszaehler_Test::values(v).pop_front();
+	ASSERT_EQ(Volkszaehler_Test::values(v).front(), r4);
+	Volkszaehler_Test::values(v).pop_front();
+
+	json_object_put(j);
+	ASSERT_TRUE( ch->buffer()->size() == 0);
+
+
+	// now try timeout and value change:
+	// expect only new value to be added:
+	t1.tv_sec += 11;
+	Reading r5(5.0, t1, pRid);
+	ch->push(r5);
+	j = Volkszaehler_Test::api_json_tuples(v, ch->buffer());
+	ASSERT_TRUE(j != 0);
+	ASSERT_TRUE(Volkszaehler_Test::values(v).size() == 1) << Volkszaehler_Test::values(v).size();
+	ASSERT_EQ(Volkszaehler_Test::values(v).front(), r5);
+	Volkszaehler_Test::values(v).pop_front();
+
+	json_object_put(j);
+	ASSERT_TRUE( ch->buffer()->size() == 0);
+
+	// now ignore one
+	t1.tv_sec += 1;
+	Reading r6(5.0, t1, pRid);
+	ch->push(r6);
+	j = Volkszaehler_Test::api_json_tuples(v, ch->buffer());
+	ASSERT_TRUE(j == 0);
+	ASSERT_TRUE(Volkszaehler_Test::values(v).size() == 0) << Volkszaehler_Test::values(v).size();
+
+	ASSERT_TRUE( ch->buffer()->size() == 0);
+
+	// and try timeout and value change again
+	// expect ignored one and new value to be added:
+
+	t1.tv_sec += 10;
+	Reading r7(7.0, t1, pRid);
+	ch->push(r7);
+	j = Volkszaehler_Test::api_json_tuples(v, ch->buffer());
+	ASSERT_TRUE(j != 0);
+	ASSERT_TRUE(Volkszaehler_Test::values(v).size() == 2) << Volkszaehler_Test::values(v).size();
+	ASSERT_EQ(Volkszaehler_Test::values(v).front(), r6);
+	Volkszaehler_Test::values(v).pop_front();
+	ASSERT_EQ(Volkszaehler_Test::values(v).front(), r7);
+	Volkszaehler_Test::values(v).pop_front();
+
+	json_object_put(j);
+	ASSERT_TRUE( ch->buffer()->size() == 0);
+
+
+}


### PR DESCRIPTION
See here a first implementation for #98.
Added an option/parameter
"duplicates" : <integer> 
to each channel config.

Default (0) means no change to current behavior -> duplicate values will be send.
Any value >0 means that duplicate values will not be send except if no value has been sent <value> seconds ago. 
If the value changes the last ignored duplicate will be send to keep the "waveform".

Implemented for volkszaehler api only.

Yet untested. I'll continue adding some unit tests but it would be good if somebody could support with testing as well.

