### PR TITLE
changed duplicate handling to not send last ignored value

### DIFF
--- a/etc/vzlogger.conf
+++ b/etc/vzlogger.conf
@@ -36,7 +36,7 @@
                 "uuid": "a8da012a-9eb4-49ed-b7f3-38c95142a90c",
                 "middleware": "http://localhost/middleware.php",
                 "identifier": "counter",
-                "duplicates": 10 // default 0 (send duplicate values), >0 = send duplicate values only each <duplicates> seconds. Before value change send last ignored value to keep waveform.
+                "duplicates": 10 // default 0 (send duplicate values), >0 = send duplicate values only each <duplicates> seconds. Activate only for abs. counter values (Zaehlerstaende) and not for impulses!
             }, {
                 "uuid": "d5c6db0f-533e-498d-a85a-be972c104b48",
                 "middleware": "http://localhost/middleware.php",

--- a/include/api/Volkszaehler.hpp
+++ b/include/api/Volkszaehler.hpp
@@ -95,7 +95,6 @@ namespace vz {
           uint64_t _last_timestamp; /**< remember last timestamp */
           // duplicate support:
           Reading *_lastReadingSent;
-          Reading *_lastReadingIgnored;
 
 		}; //class Volkszaehler
 

--- a/tests/ut_api_volkszaehler.cpp
+++ b/tests/ut_api_volkszaehler.cpp
@@ -199,13 +199,11 @@ using namespace vz::api;
 	ch->push(r3);
 
 	// now add one with a different value:
-	// then we should get r1, r2 and the new value r3:
+	// then we should get r1 and the new value r3:
 	j = Volkszaehler_Test::api_json_tuples(v, ch->buffer());
 	ASSERT_TRUE(j != 0);
-	ASSERT_TRUE(Volkszaehler_Test::values(v).size() == 3);
+	ASSERT_TRUE(Volkszaehler_Test::values(v).size() == 2);
 	ASSERT_EQ(Volkszaehler_Test::values(v).front(), r1);
-	Volkszaehler_Test::values(v).pop_front();
-	ASSERT_EQ(Volkszaehler_Test::values(v).front(), r2);
 	Volkszaehler_Test::values(v).pop_front();
 	ASSERT_EQ(Volkszaehler_Test::values(v).front(), r3);
 
@@ -257,16 +255,14 @@ using namespace vz::api;
 	ASSERT_TRUE( ch->buffer()->size() == 0);
 
 	// and try timeout and value change again
-	// expect ignored one and new value to be added:
+	// expect new value to be added:
 
 	t1.tv_sec += 10;
 	Reading r7(7.0, t1, pRid);
 	ch->push(r7);
 	j = Volkszaehler_Test::api_json_tuples(v, ch->buffer());
 	ASSERT_TRUE(j != 0);
-	ASSERT_TRUE(Volkszaehler_Test::values(v).size() == 2) << Volkszaehler_Test::values(v).size();
-	ASSERT_EQ(Volkszaehler_Test::values(v).front(), r6);
-	Volkszaehler_Test::values(v).pop_front();
+	ASSERT_TRUE(Volkszaehler_Test::values(v).size() == 1) << Volkszaehler_Test::values(v).size();
 	ASSERT_EQ(Volkszaehler_Test::values(v).front(), r7);
 	Volkszaehler_Test::values(v).pop_front();
 


### PR DESCRIPTION
Don't send the last ignored value for duplicate values. (see discussion in issue #98)
Update to #125.
To "disable" duplicate sending after timeout for now a big value should be used (e.g. 2000000 -> around 23days. Values bigger 2mio should be avoided as it will be multiplied with 1000 internally and should still fit into a signed int.) I'll add a handling for e.g. duplicate: -1 (no timeout) later if needed.