### PR TITLE
implemented avg mode for non aequidistant tuples

### DIFF
--- a/include/Buffer.hpp
+++ b/include/Buffer.hpp
@@ -69,6 +69,9 @@ class Buffer {
 	inline void set_aggmode(Buffer::aggmode m) {_aggmode=m;}
 
 	private:
+	Buffer(const Buffer &); // don't allow copy constructor
+	Buffer & operator=(const Buffer &); // and no assignment op.
+
 	std::list<Reading> _sent;
 	bool _newValues;
 
@@ -77,6 +80,8 @@ class Buffer {
 	size_t _keep;	/**< number of readings to cache for local interface */
 
 	pthread_mutex_t _mutex;
+
+	Reading *_last_avg; // keeps value and time from last reading from aggregate call for aggmode AVG
 };
 
 #endif /* _BUFFER_H_ */

--- a/src/Buffer.cpp
+++ b/src/Buffer.cpp
@@ -34,7 +34,7 @@
 #include "Buffer.hpp"
 
 Buffer::Buffer() :
-		_keep(32)
+		_keep(32), _last_avg(0)
 {
 	_newValues=false;
 	pthread_mutex_init(&_mutex, NULL);
@@ -78,9 +78,17 @@ void Buffer::aggregate(int aggtime, bool aggFixedInterval) {
 			}
 		}
 	} else if (_aggmode == AVG) {
-		Reading *latest=NULL;
-		double aggvalue=0;
-		int aggcount=0;
+		// AVG needs to handle tuples with different distances properly:
+		// so we need to consider the last tuple from last aggregate call as well
+		// and use this value as the starting point.
+		// we assume buffer values are already sorted by time here! TODO: is this always true?
+		// otherwise a sort by time would be needed but this might conflict with _last_avg
+
+		Reading *latest = NULL;
+		double aggvalue = 0;
+		double aggtimespan = 0.0;
+		unsigned int aggcount = 0;
+		Reading *previous = _last_avg;
 		for (iterator it = _sent.begin(); it!= _sent.end(); it++) {
 			if (! it->deleted()) {
 				if (!latest) {
@@ -90,16 +98,26 @@ void Buffer::aggregate(int aggtime, bool aggFixedInterval) {
 						latest=&*it;
 					}
 				}
-				aggvalue=aggvalue+it->value();
 				print(log_debug, "[%d] %f @ %f", "AVG",aggcount,it->value(),it->tvtod());
-
+				if (previous) {
+					double timespan = it->tvtod() - previous->tvtod();
+					aggvalue += previous->value() * timespan; // timespan between prev. and this one
+					aggtimespan += timespan;
+				}
+				previous = &*it;
 				aggcount++;
 			}
 		}
 		for (iterator it = _sent.begin(); it!= _sent.end(); it++) {
 			if (! it->deleted()) {
 				if (&*it==latest) {
-					it->value(aggvalue/aggcount);
+					// store the last value before we modify it.
+					if (!_last_avg) _last_avg = new Reading(*it);
+					else *_last_avg = *it;
+
+					if (aggtimespan>0.0)
+						it->value(aggvalue/aggtimespan);
+					// else keep current value (if no previous and just single value)
 					print(log_debug, "[%d] RESULT %f @ %f", "AVG",aggcount,it->value(),it->tvtod());
 				} else {
 					it->mark_delete();
@@ -203,6 +221,7 @@ char * Buffer::dump(char *dump, size_t len) {
 
 Buffer::~Buffer() {
 	pthread_mutex_destroy(&_mutex);
+	if (_last_avg) delete _last_avg;
 }
 
 /*


### PR DESCRIPTION
See here a proposal for #86.

I struggled a bit in what timespan to use as the basis. Example:

value 10 at time 1s, then value 20 at time 3s, then value 30 at time 4s:

  a) 10 * 2s (from 1s to 3s) + 20 * 1s + 30 * 0s (yet) = 15
  b) 10 * 0s + 20 * 2s (1s to 3s) + 30 * 1s (3s to 4s) = 23,33

I implemented a) with taking the last value (30 from above) in consideration for the next aggregation.

Let me know your feedback.

Implementation unit-tested only.