### PR TITLE
add startup log message and fix error on overwriting the log level by command option

### DIFF
--- a/etc/vzlogger.conf
+++ b/etc/vzlogger.conf
@@ -10,7 +10,7 @@
 {
     "retry": 30,            // how long to sleep between failed requests, in seconds
     "daemon": false,        // run periodically
-    "verbosity": 5,         // between 0 and 15
+    "verbosity": 5,         // one of 0 = log_error and log_warning, 5 = log_info, 10 = log_debug, 15 = log_finest
     "log": "/var/log/vzlogger.log",     // path to logfile, optional
 
     "local": {

--- a/include/Config_Options.hpp
+++ b/include/Config_Options.hpp
@@ -80,7 +80,7 @@ public:
 	void log(const std::string &v)    { _log = v; }
 	void logfd(FILE *fd)              { _logfd = fd; }
 	void port(const int v)      { _port = v; }
-	void verbosity(int v) { _verbosity = v; }
+	void verbosity(int v) { if (v>=0) _verbosity = v; }
 
 	void daemon(const bool v)    { _daemon = v; }
 	void local(const bool v)     { _local = v; }

--- a/src/vzlogger.cpp
+++ b/src/vzlogger.cpp
@@ -353,6 +353,10 @@ int main(int argc, char *argv[]) {
 		return EXIT_FAILURE;
 	}
 
+	// always (that's why log_error is used) print version info to log file:
+	print(log_error, "vzlogger v%s based on %s from %s started.", "main",
+		  VERSION, g_GIT_SHALONG, g_GIT_LAST_COMMIT_DATE);
+
 	//mappings = (MapContainer::Ptr)(new MapContainer());
 	try {
 		options.config_parse(mappings);
@@ -364,7 +368,10 @@ int main(int argc, char *argv[]) {
 	}
 
 	// make sure command line options override config settings, just re-parse
+	optind = 0; // otherwise the getopt_long doesn't parse from start!
 	config_parse_cli(argc, argv, &options);
+
+	print(log_error, "log level is %d", "main", options.verbosity());
 
 	curlSessionProvider = new CurlSessionProvider();
 


### PR DESCRIPTION
Implementation for PR #144.
I needed to add two lines (one with startup and one with the version) as the version get's parsed quite late and otherwise there would be lots of other log messages before the start message.
During implementation I found a bug that the command line option does not overwrite the config file option as intended. Fixed that as well (optind=0).
Fixed as well that the verbosity could be set to values <0 thus always making sure that log_error get's printed.
```
[Mar 20 21:57:21][main] vzlogger v0.4.0 based on heads/print_144-0-gfef1835f75 from Fri, 20 Mar 2015 21:48:34 +0100 started.
[Mar 20 21:57:21][main] log level is 5
```
