### PR TITLE
changed time to int64_t. return int64 to middleware instead of double

### DIFF
--- a/include/Channel.hpp
+++ b/include/Channel.hpp
@@ -62,7 +62,7 @@ class Channel {
 
 	ReadingIdentifier::Ptr identifier() {
 		if (_identifier.use_count() < 1) throw vz::VZException("Not identifier defined.") ; return _identifier; }
-	double tvtod() const          { return _last == NULL ? 0 : _last->tvtod(); }
+	int64_t time_ms() const { return _last == NULL ? 0 : _last->time_ms(); }
 
 	const char* uuid() const            { return _uuid.c_str(); }
 	const std::string apiProtocol()     { return _apiProtocol; }

--- a/include/Reading.hpp
+++ b/include/Reading.hpp
@@ -151,11 +151,12 @@ public:
 	void value(const double &v) { _value = v; }
 	double value() const  { return _value; }
 
-	double tvtod() const;
-	double tvtod(struct timeval const &tv) const;
+	int64_t time_ms() const { return ((int64_t) _time.tv_sec)*1e3 + (_time.tv_usec / 1e3); };
+	const long &time_s() const { return _time.tv_sec; }; // return only the seconds (always rounding down)
 	void time() { gettimeofday(&_time, NULL); }
 	void time(struct timeval const &v) { _time = v; }
-	struct timeval dtotv(double const &ts) const; // doesn't set the time, just returns a timeval!
+	// not needed yet: void time_from_ms( int64_t &ms );
+	void time_from_double( double const &d);
 
 	void identifier(ReadingIdentifier *rid)  { _identifier.reset(rid); }
 	const ReadingIdentifier::Ptr identifier() { return _identifier; }

--- a/include/api/Volkszaehler.hpp
+++ b/include/api/Volkszaehler.hpp
@@ -92,7 +92,7 @@ namespace vz {
 
           // Volatil
 			std::list<Reading> _values;
-          uint64_t _last_timestamp; /**< remember last timestamp */
+		  int64_t _last_timestamp; /**< remember last timestamp */
           // duplicate support:
           Reading *_lastReadingSent;
 

--- a/src/Buffer.cpp
+++ b/src/Buffer.cpp
@@ -59,19 +59,19 @@ void Buffer::aggregate(int aggtime, bool aggFixedInterval) {
 				if (!latest) {
 					latest=&*it;
 				} else {
-					if (it->tvtod() > latest->tvtod()) {
+					if (it->time_ms() > latest->time_ms()) {
 						latest=&*it;
 					}
 				}
 				aggvalue=std::max(aggvalue,it->value());
-				print(log_debug, "%f @ %f", "MAX",it->value(),it->tvtod());
+				print(log_debug, "%f @ %lld", "MAX",it->value(),it->time_ms());
 			}
 		}
 		for (iterator it = _sent.begin(); it!= _sent.end(); it++) {
 			if (! it->deleted()) {
 				if (&*it==latest) {
 					it->value(aggvalue);
-					print(log_debug, "RESULT %f @ %f", "MAX",it->value(),it->tvtod());
+					print(log_debug, "RESULT %f @ %lld", "MAX",it->value(),it->time_ms());
 				} else {
 					it->mark_delete();
 				}
@@ -94,13 +94,13 @@ void Buffer::aggregate(int aggtime, bool aggFixedInterval) {
 				if (!latest) {
 					latest=&*it;
 				} else {
-					if (it->tvtod() > latest->tvtod()) {
+					if (it->time_ms() > latest->time_ms()) {
 						latest=&*it;
 					}
 				}
-				print(log_debug, "[%d] %f @ %f", "AVG",aggcount,it->value(),it->tvtod());
+				print(log_debug, "[%d] %f @ %lld", "AVG",aggcount,it->value(),it->time_ms());
 				if (previous) {
-					double timespan = it->tvtod() - previous->tvtod();
+					double timespan = ((double)(it->time_ms() - previous->time_ms())) / 1000.0;
 					aggvalue += previous->value() * timespan; // timespan between prev. and this one
 					aggtimespan += timespan;
 				}
@@ -118,7 +118,7 @@ void Buffer::aggregate(int aggtime, bool aggFixedInterval) {
 					if (aggtimespan>0.0)
 						it->value(aggvalue/aggtimespan);
 					// else keep current value (if no previous and just single value)
-					print(log_debug, "[%d] RESULT %f @ %f", "AVG",aggcount,it->value(),it->tvtod());
+					print(log_debug, "[%d] RESULT %f @ %lld", "AVG",aggcount,it->value(),it->time_ms());
 				} else {
 					it->mark_delete();
 				}
@@ -132,19 +132,19 @@ void Buffer::aggregate(int aggtime, bool aggFixedInterval) {
 				if (!latest) {
 					latest=&*it;
 				} else {
-					if (it->tvtod() > latest->tvtod()) {
+					if (it->time_ms() > latest->time_ms()) {
 						latest=&*it;
 					}
 				}
 				aggvalue=aggvalue+it->value();
-				print(log_debug, "%f @ %f", "SUM",it->value(),it->tvtod());
+				print(log_debug, "%f @ %lld", "SUM",it->value(),it->time_ms());
 			}
 		}
 		for (iterator it = _sent.begin(); it!= _sent.end(); it++) {
 			if (! it->deleted()) {
 				if (&*it==latest) {
 					it->value(aggvalue);
-					print(log_debug, "RESULT %f @ %f", "SUM",it->value(),it->tvtod());
+					print(log_debug, "RESULT %f @ %lld", "SUM",it->value(),it->time_ms());
 				} else {
 					it->mark_delete();
 				}
@@ -157,7 +157,7 @@ void Buffer::aggregate(int aggtime, bool aggFixedInterval) {
 		for (iterator it = _sent.begin(); it!= _sent.end(); it++) {
 			if (! it->deleted()) {
 				tv.tv_usec = 0;
-				tv.tv_sec = aggtime * (long int)(it->tvtod() / aggtime);
+				tv.tv_sec = aggtime * (long int)((it->time_ms()/1000) / aggtime);
 				it->time(tv);
 			}
 		}

--- a/src/Reading.cpp
+++ b/src/Reading.cpp
@@ -37,15 +37,17 @@ Reading::Reading()
 		: _deleted(false)
 		, _value(0)
 {
+	_time.tv_sec = 0;
+	_time.tv_usec = 0;
 }
 
 Reading::Reading(ReadingIdentifier::Ptr pIndentifier)
 		: _deleted(false)
 		, _value(0)
-								//    , time(0)
 		, _identifier(pIndentifier)
 {
-
+	_time.tv_sec = 0;
+	_time.tv_usec = 0;
 }
 Reading::Reading(
 	double pValue
@@ -67,26 +69,15 @@ Reading::Reading(
 		, _time(orig._time)
 		, _identifier (orig._identifier)
 {
-//	printf("+==>Copy: %f %f orig %f %f\n", tvtod(), _value, orig.tvtod(), orig._value);
 }
 
-double Reading::tvtod() const {
-	return (double)_time.tv_sec + ((double)_time.tv_usec / 1e6);
-}
-
-double Reading::tvtod(struct timeval const &tv) const {
-	return (double)tv.tv_sec + ((double)tv.tv_usec / 1e6);
-}
-
-struct timeval Reading::dtotv(double const &ts) const {
+void Reading::time_from_double(double const &ts)
+{
 	double integral;
 	double fraction = modf(ts, &integral);
 
-	struct timeval tv;
-	tv.tv_usec = (long int) (fraction * 1e6);
-	tv.tv_sec = (long int) integral;
-
-	return tv;
+	_time.tv_usec = (long int) (fraction * 1e6);
+	_time.tv_sec = (long int) integral;
 }
 
 ReadingIdentifier::Ptr reading_id_parse(meter_protocol_t protocol, const char *string) {

--- a/src/api/MySmartGrid.cpp
+++ b/src/api/MySmartGrid.cpp
@@ -499,16 +499,16 @@ json_object * vz::api::MySmartGrid::_json_object_measurements(Buffer::Ptr buf) {
 
 	//print(log_debug, "MSG-API, buffer has %d element.", channel()->name(), buf->size());
 	if (_values.size() ) {
-		timestamp = _values.back().tvtod();
+		timestamp = _values.back().time_s();
 		value     = _values.back().value();
 	}
 
 	// copy all values to local buffer queue
 	buf->lock();
 	for (it = buf->begin(); it != buf->end(); it++) {
-		if (timestamp < (long)it->tvtod() /*&& value != (long)(it->value() * _scaler)*/ ) {
+		if (timestamp < it->time_s() /*&& value != (long)(it->value() * _scaler)*/ ) {
 			_values.push_back(*it);
-			timestamp = it->tvtod();
+			timestamp = it->time_s();
 			value     = it->value() * _scaler;
 		}
 		it->mark_delete();
@@ -519,7 +519,7 @@ json_object * vz::api::MySmartGrid::_json_object_measurements(Buffer::Ptr buf) {
 	//print(log_debug, "Valuescounter: %d", channel()->name(), _values.size());
 
 	for (it = _values.begin(); it != _values.end(); it++) {
-		timestamp = it->tvtod();
+		timestamp = it->time_s();
 		value     = it->value() * _scaler;
 		print(log_debug, "==> %ld, %lf - %ld", channel()->name(), timestamp, it->value(), value);
 	}
@@ -533,7 +533,7 @@ json_object * vz::api::MySmartGrid::_json_object_measurements(Buffer::Ptr buf) {
 
 		// TODO use long int of new json-c version
 		// API requires milliseconds => * 1000
-		long timestamp = it->tvtod();
+		long timestamp = it->time_s();
 		long value = it->value() * _scaler;
 
 		if (_first_counter < 1 ) {

--- a/src/protocols/MeterFile.cpp
+++ b/src/protocols/MeterFile.cpp
@@ -167,7 +167,7 @@ ssize_t MeterFile::read(std::vector<Reading> &rds, size_t n) {
 			rds[i].identifier(rid);
 			if (found >= 1) {
 				if (timestamp >=0.0)
-					rds[i].time(rds[i].dtotv(timestamp)); // convert double to timevals
+					rds[i].time_from_double(timestamp);
 				else
 					rds[i].time(); // use current timestamp
 				i++; // read successfully

--- a/src/threads.cpp
+++ b/src/threads.cpp
@@ -81,9 +81,9 @@ void * reading_thread(void *arg) {
 					char identifier[MAX_IDENTIFIER_LEN];
 					for (size_t i = 0; i < n; i++) {
 						rds[i].unparse(/*mtr->protocolId(),*/ identifier, MAX_IDENTIFIER_LEN);
-						print(log_debug, "Reading: id=%s/%s value=%.2f ts=%.3f", mtr->name(),
+						print(log_debug, "Reading: id=%s/%s value=%.2f ts=%lld", mtr->name(),
 								identifier, rds[i].identifier()->toString().c_str(),
-								rds[i].value(), rds[i].tvtod());
+								rds[i].value(), rds[i].time_ms());
 					}
 				}
 
@@ -102,12 +102,12 @@ void * reading_thread(void *arg) {
 					for (size_t i = 0; i < n; i++) {
 						if (*rds[i].identifier().get() == *(*ch)->identifier().get()) {
 							//print(log_debug, "found channel", mtr->name());
-							if ((*ch)->tvtod() < rds[i].tvtod()) {
+							if ((*ch)->time_ms() < rds[i].time_ms()) {
 								(*ch)->last(&rds[i]);
 							}
 
-							print(log_info, "Adding reading to queue (value=%.2f ts=%.3f)", (*ch)->name(),
-									rds[i].value(), rds[i].tvtod());
+							print(log_info, "Adding reading to queue (value=%.2f ts=%lld)", (*ch)->name(),
+									rds[i].value(), rds[i].time_ms());
 							(*ch)->push(rds[i]);
 
 							if (add == NULL) {

--- a/tests/mocks/Channel.hpp
+++ b/tests/mocks/Channel.hpp
@@ -22,7 +22,7 @@ public:
 	MOCK_METHOD0( apiProtocol, const std::string());
 	MOCK_METHOD0( buffer, Buffer::Ptr());
 	MOCK_METHOD0( identifier, ReadingIdentifier::Ptr());
-	MOCK_CONST_METHOD0( tvtod, double ());
+	MOCK_CONST_METHOD0( time_ms, int64_t ());
 	MOCK_METHOD1( last, void (Reading *rd));
 	MOCK_METHOD1( push, void (const Reading &rd));
 	MOCK_METHOD0( notify, void ());

--- a/tests/ut_MeterFile.cpp
+++ b/tests/ut_MeterFile.cpp
@@ -159,10 +159,13 @@ TEST(MeterFile, reading_times)
 	t.tv_sec=1001;
 	t.tv_usec=1;
 	r.time(t);
-	ASSERT_TRUE(abs(1001.000001 - r.tvtod())<0.0001) << r.tvtod();
-	
-	r.time(r.dtotv(1002.00001));
-	ASSERT_TRUE(abs(1002.00001 - r.tvtod())<0.0001) << r.tvtod();	
+	ASSERT_EQ(1001000ll, r.time_ms()) << r.time_ms();
+	t.tv_usec = 1000;
+	r.time(t);
+	ASSERT_EQ(1001001ll, r.time_ms()) << r.time_ms();
+
+	r.time_from_double(1002.00001);
+	ASSERT_EQ(1002000ll, r.time_ms()) << r.time_ms();
 }
 
 TEST(MeterFile, format3) {
@@ -193,7 +196,7 @@ TEST(MeterFile, format3) {
 	ReadingIdentifier *p = rds[0].identifier().get();
 	double value = rds[0].value();
 	EXPECT_EQ(32552, value);
-	EXPECT_TRUE(abs(1001.2 -rds[0].tvtod())<0.01) << rds[0].tvtod();
+	EXPECT_EQ(1001200ll, rds[0].time_ms()) << rds[0].time_ms();
 
 	StringIdentifier *o = dynamic_cast<StringIdentifier*>(p);
 	ASSERT_NE((StringIdentifier*)0, o);
@@ -203,7 +206,7 @@ TEST(MeterFile, format3) {
 	p = rds[1].identifier().get();
 	o = dynamic_cast<StringIdentifier*>(p);
 	EXPECT_EQ(32552.5, value);
-	EXPECT_EQ(1002.5f, rds[1].tvtod());	
+	EXPECT_EQ(1002500ll, rds[1].time_ms());
 	ASSERT_NE((StringIdentifier*)0, o);
 	EXPECT_EQ(StringIdentifier("id2"), *o);
 


### PR DESCRIPTION
Implementation / fix for Issue #146 (timestamps should be integers when sending to middleware).
Changed class Reading time handling to int64_t instead of double.
Return time_ms() (int64_t returning the ms since 1.1.1970) to middleware.

Only unit tested. Please (somebody) test!