### PR TITLE
first version with support for UART and GPIO

### DIFF
--- a/etc/vzlogger_generic.schema.json
+++ b/etc/vzlogger_generic.schema.json
@@ -134,7 +134,9 @@
             { "$ref": "#/definitions/meter" },
             { "properties": {
                 "protocol": { "type": "string", "enum": ["s0"] },
-                "device": { "type": "string", "description": "device the meter is connected to. E.g. /dev/ttyUSB0" },
+                "device": { "type": "string", "description": "UART device the meter is connected to. E.g. /dev/ttyUSB0" },
+                "gpio": { "type": "integer", "default": -1, "description": "Number of GPIO port to be used. If this is set >-1 then device is ignored." },
+                "configureGPIO": { "type": "boolean", "default": true, "description": "If true then vzlogger will export, configure,... the GPIO port. Needs proper access rights to /sys/class/gpio/." },
                 "resolution": { "type": "integer", "default": 1000, "description": "number of impulses per kWh" }
             },
             "required": [ "protocol", "device" ]

--- a/etc/vzlogger_generic.schema.json
+++ b/etc/vzlogger_generic.schema.json
@@ -137,7 +137,8 @@
                 "device": { "type": "string", "description": "UART device the meter is connected to. E.g. /dev/ttyUSB0" },
                 "gpio": { "type": "integer", "default": -1, "description": "Number of GPIO port to be used. If this is set >-1 then device is ignored." },
                 "configureGPIO": { "type": "boolean", "default": true, "description": "If true then vzlogger will export, configure,... the GPIO port. Needs proper access rights to /sys/class/gpio/." },
-                "resolution": { "type": "integer", "default": 1000, "description": "number of impulses per kWh" }
+                "resolution": { "type": "integer", "default": 1000, "description": "number of impulses per kWh" },
+                "debounce_delay": { "type": "integer", "default": 30, "description": "Delay in ms until the next edge is detected" }
             },
             "required": [ "protocol", "device" ]
             }

--- a/include/protocols/MeterS0.hpp
+++ b/include/protocols/MeterS0.hpp
@@ -81,6 +81,7 @@ public:
     HWIF * _hwif;
 
 	int _resolution;
+	int _debounce_delay_ms;
 	int _counter;
 
 	bool _impulseReceived;		// first impulse received

--- a/include/protocols/MeterS0.hpp
+++ b/include/protocols/MeterS0.hpp
@@ -32,6 +32,43 @@
 
 class MeterS0 : public vz::protocol::Protocol {
 
+	class HWIF {
+	public:
+		virtual ~HWIF() {};
+		virtual bool _open() = 0;
+		virtual bool _close() = 0;
+		virtual bool waitForImpulse() = 0;
+	};
+
+	class HWIF_UART : public HWIF {
+	public:
+		HWIF_UART(const std::list<Option> &options);
+		virtual ~HWIF_UART();
+
+		virtual bool _open();
+		virtual bool _close();
+		virtual bool waitForImpulse();
+	protected:
+		std::string _device;
+		int _fd;					// file descriptor of UART
+		struct termios _old_tio;	// required to reset UART
+	};
+
+	class HWIF_GPIO : public HWIF {
+	public:
+		HWIF_GPIO(const std::list<Option> &options);
+		virtual ~HWIF_GPIO();
+
+		virtual bool _open();
+		virtual bool _close();
+		virtual bool waitForImpulse();
+	protected:
+		int _fd;
+		int _gpiopin;
+		bool _configureGPIO; // try export,...
+		std::string _device;
+	};
+
 public:
 	MeterS0(std::list<Option> options);
 	virtual ~MeterS0();
@@ -40,17 +77,11 @@ public:
 	int close();
 	ssize_t read(std::vector<Reading> &rds, size_t n);
 
-  private:
-	int _open_socket(const char *node, const char *service);
-	int _open_device(struct termios *old_tio, speed_t baudrate);
-
   protected:
-	std::string _device;
+    HWIF * _hwif;
+
 	int _resolution;
 	int _counter;
-
-	int _fd;					// file descriptor of port
-	struct termios _old_tio;	// required to reset port
 
 	bool _impulseReceived;		// first impulse received
 	struct timeval _time_last;	// timestamp of last impulse

--- a/src/protocols/MeterS0.cpp
+++ b/src/protocols/MeterS0.cpp
@@ -29,6 +29,7 @@
 #include <string.h>
 #include <sys/time.h>
 #include <errno.h>
+#include <poll.h>
 
 #include "protocols/MeterS0.hpp"
 #include "Options.hpp"
@@ -36,15 +37,27 @@
 
 MeterS0::MeterS0(std::list<Option> options)
 		: Protocol("s0")
+		, _hwif(0)
 		, _counter(0)
 {
 	OptionList optlist;
 
+	// check which HWIF to use:
+	// if "gpio" is given -> GPIO
+	// else (assuming "device") -> UART
+	bool use_gpio = false;
+
 	try {
-		_device = optlist.lookup_string(options, "device");
+		int gpiopin = optlist.lookup_int(options, "gpio");
+		if (gpiopin >=0 ) use_gpio = true;
 	} catch (vz::VZException &e) {
-		print(log_error, "Missing device or invalid type", "");
-		throw;
+			// ignore
+	}
+
+	if (use_gpio) {
+		_hwif = new HWIF_GPIO(options);
+	} else {
+		_hwif = new HWIF_UART(options);
 	}
 
 	try {
@@ -58,18 +71,106 @@ MeterS0::MeterS0(std::list<Option> options)
 	if (_resolution < 1) throw vz::VZException("Resolution must be greater than 0.");
 }
 
-MeterS0::~MeterS0() {
-	//free((void*)_device);
+MeterS0::~MeterS0()
+{
+	if (_hwif) delete _hwif;
 }
 
 int MeterS0::open() {
 
-	/* open port */
+	if (!_hwif) return ERR;
+
+	if (!_hwif->_open()) return ERR;
+
+	// have yet to wait for very first impulse
+	_impulseReceived = false;
+
+	return SUCCESS;
+}
+
+int MeterS0::close() {
+	if (!_hwif) return ERR;
+
+	return (_hwif->_close() ? SUCCESS : ERR);
+}
+
+ssize_t MeterS0::read(std::vector<Reading> &rds, size_t n) {
+
+	struct timeval time_now;
+
+	if (!_hwif) return 0;
+	if (n<2) return 0; // would be worth a debug msg!
+
+	// wait for very first impulse
+	if (!_impulseReceived) {
+
+		if (!_hwif->waitForImpulse()) return 0;
+
+		gettimeofday(&_time_last, NULL);
+
+		_impulseReceived = true;
+
+		// store timestamp
+		rds[0].identifier(new StringIdentifier("Impulse"));
+		rds[0].time(_time_last);
+		rds[0].value(1);
+
+		return 1;
+	}
+
+	if (!_hwif->waitForImpulse()) return 0;
+
+	gettimeofday(&time_now, NULL);
+
+	// _time_last is initialized at this point
+	double t1 = _time_last.tv_sec + _time_last.tv_usec / 1e6;
+	double t2 = time_now.tv_sec + time_now.tv_usec / 1e6;
+	double value = 3600000 / ((t2-t1) * _resolution);
+
+	memcpy(&_time_last, &time_now, sizeof(struct timeval));
+
+	// store current timestamp
+	rds[0].identifier(new StringIdentifier("Power"));
+	rds[0].time(time_now);
+	rds[0].value(value);
+
+	rds[1].identifier(new StringIdentifier("Impulse"));
+	rds[1].time(time_now);
+	rds[1].value(1);
+
+	print(log_debug, "Reading S0 - n=%d power=%f", name().c_str(), n, rds[0].value());
+	// wait some ms for debouncing
+	usleep(30000); // todo shall we keep this or move to hwif? (or do we need it at all?)
+
+	return 2;
+}
+
+MeterS0::HWIF_UART::HWIF_UART(const std::list<Option> &options) :
+	_fd(-1)
+{
+	OptionList optlist;
+
+	try {
+		_device = optlist.lookup_string(options, "device");
+	} catch (vz::VZException &e) {
+		print(log_error, "Missing device or invalid type", "");
+		throw;
+	}
+}
+
+MeterS0::HWIF_UART::~HWIF_UART()
+{
+	if (_fd>=0) _close();
+}
+
+bool MeterS0::HWIF_UART::_open()
+{
+	// open port
 	int fd = ::open(_device.c_str(), O_RDWR | O_NOCTTY);
 
 	if (fd < 0) {
 		print(log_error, "open(%s): %s", "", _device.c_str(), strerror(errno));
-		return ERR;
+		return false;
 	}
 
 	// save current port settings
@@ -92,69 +193,159 @@ int MeterS0::open() {
 	tcsetattr(fd, TCSANOW, &tio);
 	_fd = fd;
 
-
-	// have yet to wait for very first impulse
-	_impulseReceived = false;
-
-	return SUCCESS;
+	return true;
 }
 
-int MeterS0::close() {
+bool MeterS0::HWIF_UART::_close()
+{
+	if (_fd<0) return false;
 
-	tcsetattr(_fd, TCSANOW, &_old_tio); /* reset serial port */
+	tcsetattr(_fd, TCSANOW, &_old_tio); // reset serial port
 
 	::close(_fd);
-	return SUCCESS; /* close serial port */
+	_fd = -1;
+
+	return true;
 }
 
-ssize_t MeterS0::read(std::vector<Reading> &rds, size_t n) {
-
-	struct timeval time_now;
+bool MeterS0::HWIF_UART::waitForImpulse()
+{
+	if (_fd<0) return false;
 	char buf[8];
 
-	/* clear input buffer */
+	// clear input buffer
 	tcflush(_fd, TCIOFLUSH);
 
-	// wait for very first impulse
-	if (!_impulseReceived) {
-		// blocking until one character/pulse is read
-		if (::read(_fd, buf, 8) < 1) return 0;
-		gettimeofday(&_time_last, NULL);
-
-		_impulseReceived = true;
-
-		// store timestamp
-		rds[0].identifier(new StringIdentifier("Impulse"));
-		rds[0].time(_time_last);
-		rds[0].value(1);
-
-		return 1;
-	}
-
 	// blocking until one character/pulse is read
-	if (::read(_fd, buf, 8) < 1) return 0;
-	gettimeofday(&time_now, NULL);
+	if (::read(_fd, buf, 8) < 1) return false;
 
-	// _time_last is initialized at this point
-	double t1 = _time_last.tv_sec + _time_last.tv_usec / 1e6;
-	double t2 = time_now.tv_sec + time_now.tv_usec / 1e6;
-	double value = 3600000 / ((t2-t1) * _resolution);
-
-	memcpy(&_time_last, &time_now, sizeof(struct timeval));
-
-	// store current timestamp
-	rds[0].identifier(new StringIdentifier("Power"));
-	rds[0].time(time_now);
-	rds[0].value(value);
-
-	rds[1].identifier(new StringIdentifier("Impulse"));
-	rds[1].time(time_now);
-	rds[1].value(1);
-
-	print(log_debug, "Reading S0 - n=%d power=%f", name().c_str(), n, rds[0].value());
-	// wait some ms for debouncing
-	usleep(30000);
-
-	return 2;
+	return true;
 }
 
+MeterS0::HWIF_GPIO::HWIF_GPIO(const std::list<Option> &options) :
+	_fd(-1), _gpiopin(-1), _configureGPIO(true)
+{
+	OptionList optlist;
+
+	try {
+		_gpiopin = optlist.lookup_int(options, "gpio");
+	} catch (vz::VZException &e) {
+		print(log_error, "Missing gpio or invalid type (expect int)", "S0");
+		throw;
+	}
+	if (_gpiopin <0 ) throw vz::VZException("invalid (<0) gpio(pin) set");
+
+	try {
+		_configureGPIO = optlist.lookup_bool(options, "configureGPIO");
+	} catch (vz::VZException &e) {
+		print(log_info, "Missing bool configureGPIO using default true", "S0");
+		_configureGPIO = true;
+	}
+
+	_device.append("/sys/class/gpio/gpio");
+	_device.append(std::to_string(_gpiopin));
+	_device.append("/value");
+
+}
+
+MeterS0::HWIF_GPIO::~HWIF_GPIO()
+{
+	if (_fd>=0) _close();
+}
+
+bool MeterS0::HWIF_GPIO::_open()
+{
+	std::string name;
+	int fd;
+	unsigned int res;
+
+	if (!::access(_device.c_str(),F_OK)){
+		// exists
+	} else {
+		if (_configureGPIO) {
+			fd = ::open("/sys/class/gpio/export",O_WRONLY);
+			if (fd<0) throw vz::VZException("open export failed");
+			name.clear();
+			name.append(std::to_string(_gpiopin));
+			name.append("\n");
+
+			res=write(fd,name.c_str(), name.length()+1); // is the trailing zero really needed?
+			if ((name.length()+1)!=res) throw vz::VZException("export failed");
+			::close(fd);
+		} else return false; // doesn't exist and we shall not configure
+	}
+
+	// now it exists:
+	if (_configureGPIO) {
+		name.clear();
+		name.append("/sys/class/gpio/gpio");
+		name.append(std::to_string(_gpiopin));
+		name.append("/direction");
+		fd = ::open(name.c_str(), O_WRONLY);
+		if (fd<0) throw vz::VZException("open direction failed");
+		res=::write(fd,"in\n",3);
+		if (3!=res) throw vz::VZException("set direction failed");
+		if (::close(fd)<0) throw vz::VZException("set direction failed");
+
+		name.clear();
+		name.append("/sys/class/gpio/gpio");
+		name.append(std::to_string(_gpiopin));
+		name.append("/edge");
+		fd = ::open(name.c_str(), O_WRONLY);
+		if (fd<0) throw vz::VZException("open edge failed");
+		res=::write(fd,"rising\n",7);
+		if (7!=res) throw vz::VZException("set edge failed");
+		if (::close(fd)<0) throw vz::VZException("set edge failed");
+
+		name.clear();
+		name.append("/sys/class/gpio/gpio");
+		name.append(std::to_string(_gpiopin));
+		name.append("/active_low");
+		fd = ::open(name.c_str(), O_WRONLY);
+		if (fd<0) throw vz::VZException("open active_low failed");
+		res=::write(fd,"0\n",2);
+		if (2!=res) throw vz::VZException("set active_low failed");
+		if (::close(fd)<0) throw vz::VZException("set active_low failed");
+	}
+
+	fd = ::open( _device.c_str(), O_RDONLY | O_EXCL); // EXCL really needed?
+	if (fd < 0) {
+		print(log_error, "open(%s): %s", "", _device.c_str(), strerror(errno));
+		return false;
+	}
+
+	_fd = fd;
+
+	return true;
+}
+
+bool MeterS0::HWIF_GPIO::_close()
+{
+	if (_fd<0) return false;
+
+	::close(_fd);
+	_fd = -1;
+
+	return true;
+}
+
+bool MeterS0::HWIF_GPIO::waitForImpulse()
+{
+	unsigned char buf[2];
+	if (_fd<0) return false;
+
+	struct pollfd poll_fd;
+	poll_fd.fd = _fd;
+	poll_fd.events = POLLPRI|POLLERR;
+	poll_fd.revents = 0;
+
+	int rv = poll(&poll_fd, 1, -1);    // block endlessly
+	print(log_debug, "MeterS0:HWIF_GPIO:first poll returned %d", "S0", rv);
+	if (rv > 0) {
+		if (poll_fd.revents & POLLPRI) {
+			if (::pread(_fd, buf, 1, 0) < 1) return false;
+		} else return false;
+	} else return false;
+
+	return true;
+}


### PR DESCRIPTION
As discussed at the developer meeting see here the first proposal for the native support of GPIO.
Inputs taken from @r00t- 's bases0 tree and my s0_gpio tree. See #110 and #85.
Old configs should work as before.
If "gpio" is set >=0 this is assumed the gpiopin to be used.
With "configureGPIO" : false you can disable the auto configuration of the gpio pin (e.g. if run without root  or sufficient privileges).
Untested (as I have no S0 here)!
