### PR TITLE
Configuration cleanup

### DIFF
--- a/etc/vzlogger.conf
+++ b/etc/vzlogger.conf
@@ -11,85 +11,112 @@
  */
 
 {
-    "retry": 30,            // how long to sleep between failed requests, in seconds
+    // General settings
     "daemon": false,        // run periodically
-    "verbosity": 5,         // one of 0 = log_error and log_warning, 5 = log_info, 10 = log_debug, 15 = log_finest
-    "log": "/var/log/vzlogger.log",     // path to logfile, optional
+    "verbosity": 5,         // log verbosity (0=log_error and log_warning, 5=log_info, 10=log_debug, 15=log_finest)
+    "log": "/var/log/vzlogger.log", // log file, optional
+    "retry": 30,            // http retry delay in seconds
 
+    // Build-in HTTP server
     "local": {
-        "enabled": false,   // should we start the local HTTPd for serving live readings?
-        "port": 8080,       // the TCP port for the local HTTPd
-        "index": true,      // should we provide a index listing of available channels if no UUID was requested?
-        "timeout": 30,      // timeout for long polling comet requests, 0 disables comet, in seconds
-        "buffer": -1       // how long to buffer readings for the local interface, in seconds (if greater 0) or how many tuples to return per channel if <0 (-3 = return 3 tuples), default -1
+        "enabled": false,   // enable local HTTPd for serving live readings
+        "port": 8080,       // TCP port for local HTTPd
+        "index": true,      // provide index listing of available channels if no UUID was requested
+        "timeout": 30,      // timeout for long polling comet requests in seconds (0 disables comet)
+        "buffer": -1        // HTTPd buffer configuration for serving readings, default -1
+                            //   >0: number of seconds of readings to serve
+                            //   <0: number of tuples to server per channel (e.g. -3 will serve 3 tuples)
     },
 
+    // Meter configuration
     "meters": [
         {
+            // Example SML meter
+
             "enabled": false,               // disabled meters will be ignored (default)
-            "skip": false,                  // if enabled, errors when opening meter will lead to meter being ignored
-            "protocol": "sml",              // see 'vzlogger -h' for list of available protocols
-            "host": "http://localhost/meinzaehler.dyndns.info:7331",
-            "aggtime": 10,                  // aggregate all signals and give one update to middleware every 10 seconds 
+            "skip": false,                  // errors when opening meter may be ignored if enabled
+            "protocol": "sml",              // meter protocol, see 'vzlogger -h' for full list
+            "device": "/dev/ttyUSB1",       // meter device
+//          "host": "http://my.ddns.net::7331",   // uri if meter not locally connected using <device>
+
+            "aggtime": 10,                  // aggregate meter readings and send middleware update after <aggtime> seconds
+
             "channels": [{
-                "api": "volkszaehler",      // default middleware api: volkszaehler.org
+                "api": "volkszaehler",      // middleware api, default volkszaehler
                 "uuid": "fde8f1d0-c5d0-11e0-856e-f9e4360ced10",
                 "middleware": "http://localhost/middleware.php",
-                "identifier": "power",      // alias for '1-0:1.7.ff', see 'vzlogger -h' for list of available aliases
-                "aggmode": "AVG"            // use with "aggtime": "AVG" for Power, "MAX" for Counter
+                "identifier": "power"       // OBIS identifier (alias for '1-0:1.7.ff')
+                                            //   see 'vzlogger -h' for available aliases
+                                            //   see 'vzlogger -v20' for available identifiers for attached meters
             }, {
                 "uuid": "a8da012a-9eb4-49ed-b7f3-38c95142a90c",
                 "middleware": "http://localhost/middleware.php",
-                "identifier": "counter",
-                "duplicates": 10 // default 0 (send duplicate values), >0 = send duplicate values only each <duplicates> seconds. Activate only for abs. counter values (Zaehlerstaende) and not for impulses!
+                "identifier": "counter",    // OBIS identifier
+                "duplicates": 10            // duplicate handling, default 0 (send duplicate values)
+                                            //   >0: send duplicate values only each <duplicates> seconds
+                                            // Activate only for abs. counter values (Zaehlerstaende) and not for impulses
             }, {
                 "uuid": "d5c6db0f-533e-498d-a85a-be972c104b48",
                 "middleware": "http://localhost/middleware.php",
-                "identifier": "1-0:1.8.0",   // see 'vzlogger -v20' for an output with all available identifiers/OBIS ids
-                "aggmode": "MAX"            // use with "aggtime": "AVG" for Power, "MAX" for Counter
+                "identifier": "1-0:1.8.0"   // OBIS identifier
             }]
         },
         {
-            "enabled": false,               // disabled meters will be ignored
-            "skip": false,                  // if enabled, errors when opening meter will lead to meter being ignored
-            "protocol": "s0",
-            "aggtime": 300,                 // aggregate all signals and give one update to middleware every 300 seconds
-            "aggfixedinterval": true,       // round all timestamps to middleware to nearest aggtime
-            "device": "/dev/ttyUSB0",
+            // Example S0 meter
+
+            "enabled": false,               // disabled meters will be ignored (default)
+            "skip": false,                  // errors when opening meter may be ignored if enabled
+            "protocol": "s0",               // meter protocol, see 'vzlogger -h' for full list
+            "device": "/dev/ttyUSB0",       // meter device
+
+            "aggtime": 300,                 // aggregate meter readings and send middleware update after <aggtime> seconds
+            "aggfixedinterval": true,       // round timestamps to nearest <aggtime> before sending to middleware
+            "aggmode": "SUM",               // aggregation mode: aggregate meter readings during <aggtime> interval
+                                            //   "SUM": add readings (use for s0 impulses)
+                                            //   "MAX": maximum value (use for meters sending absolute readings)
+                                            //   "AVG": average value (use for meters sending current usage)
+
             "channel": {
                 "identifier": "Impulse",    // s0 meter knows "Impulse" and "Power"
                 "uuid": "d495a390-f747-11e0-b3ca-f7890e45c7b2",
-                "middleware": "http://localhost/middleware.php",
-                "aggmode": "SUM"            // add all s0 intervals in the aggregation
+                "middleware": "http://localhost/middleware.php"
             }
         },
         {
+            // Example D0 meter
+
             "enabled": false,               // disabled meters will be ignored (default)
-            "skip": false,                  // if enabled, errors when opening meter will lead to meter being ignored
-            "protocol": "d0",               // see 'vzlogger -h' for list of available protocols
-            "device": "/dev/ttyUSB0",
-            "dump_file": "/var/log/dumpD0.txt", // optional, if set logs all received/transmitted data to this file
+            "skip": false,                  // errors when opening meter may be ignored if enabled
+            "protocol": "d0",               // meter protocol, see 'vzlogger -h' for full list
+            "device": "/dev/ttyUSB0",       // meter device
+            "dump_file": "/var/log/d0.txt", // detailed log file for all received/transmitted data (optional)
+
+            "parity": "7E1",                // Serial parity, 7E1 or 8N1
+            "baudrate": 9600,               // Serial baud rate, typically 9600 or 300
+
+            // optional D0 interface settings
+//          "pullseq": "2F3F210D0A",        // Pull sequence in 'hex'
+//          "ackseq": "063030300d0a",       // optional (default: keine Antwortsequenz auf Zaehlerantwort) kann entweder feste hex-Sequenz sein (z.B. 063035300d0a für mode C mit 9600bd oder 063030300d0a = 300bd) oder kann auf "auto" gesetzt werden, damit die Sequenz autom. berechnet wird und autom. auf die max. Baudrate umgeschaltet wird (baudrate_read wird dann ignoriert)
 //          "read_timeout": 10, // optional, default 10s. Timeout value in secs between single bytes received from device
 //          "baudrate_change_delay": 400, // optional, default none. Delay value in ms after ACKSEQ send before baudrate change
-            "parity": "7E1",                // oder 8N1
-            "baudrate": 9600,               // oder 300
-//          "pullseq": "2F3F210D0A",        // Pullsequenz in 'hex'
-//          "ackseq": "063030300d0a",       // optional (default: keine Antwortsequenz auf Zaehlerantwort) kann entweder feste hex-Sequenz sein (z.B. 063035300d0a für mode C mit 9600bd oder 063030300d0a = 300bd) oder kann auf "auto" gesetzt werden, damit die Sequenz autom. berechnet wird und autom. auf die max. Baudrate umgeschaltet wird (baudrate_read wird dann ignoriert)
 //          "baudrate_read": 300,           // Baudratenumschaltung auf gewünschte Baudrate, abhängig von Zählerantwort
-//          "aggtime": 20,                  // in Sekunden
-//          "aggmode": "AVG",               // Mittelwert für Leistung, "MAX" für Zähler, "SUM" für Counter
+
+//          "aggtime": 20,                  // aggregate meter readings and send middleware update after <aggtime> seconds
+//          "aggmode": "AVG",               // aggregation mode: aggregate meter readings during <aggtime> interval
             "interval": 6,                  // Wartezeit in Sekunden bis neue Werte in die middleware übertragen werden
-            "channel": {                    // Beispiel-channel
+
+            "channel": {
                 "uuid": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeee",
-                "middleware": "http://127.0.0.1/middleware.php",
-                "identifier": "1-0:1.8.1"   // alias for '1-0:1.8.1', see 'vzlogger -h' for list of available aliases
+                "middleware": "http://localhost/middleware.php",
+                "identifier": "1-0:1.8.1"   // OBIS identifier
             }
         },
 
         // examples for non-device protocols
         {
             "enabled": false,               // disabled meters will be ignored
-            "skip": false,                  // if enabled, errors when opening meter will lead to meter being ignored
+            "skip": false,                  // errors when opening meter may be ignored if enabled
+
             "protocol": "random",
             "interval": 2,
             "max": 40.0,                    // has to be double!
@@ -101,7 +128,8 @@
         },
         {
             "enabled": false,               // disabled meters will be ignored
-            "skip": false,                  // if enabled, errors when opening meter will lead to meter being ignored
+            "skip": false,                  // errors when opening meter may be ignored if enabled
+
             "protocol": "file",
             "path": "/proc/loadavg",
 //          "format": "$i $v $t",           // a format string for parsing complex logfiles
@@ -115,13 +143,14 @@
         // examples for Flukso-based sensors
         {
             "enabled": false,               // disabled meters will be ignored
-            "skip": false,                  // if enabled, errors when opening meter will lead to meter being ignored
+            "skip": false,                  // errors when opening meter may be ignored if enabled
+
             "protocol": "fluksov2",
             "fifo": "/var/spid/delta/out",
             "channel": {
                 "uuid": "3b4da450-42a8-11e1-8b8d-c526d853edec",
                 "middleware": "http://localhost/middleware.php",
-                "identifier": "sensor0/power" // or "sensor2/consumption" e.g.
+                "identifier": "sensor0/power" // or "sensor2/consumption"
             }
         }
     ]

--- a/etc/vzlogger.conf
+++ b/etc/vzlogger.conf
@@ -28,6 +28,13 @@
                             //   <0: number of tuples to server per channel (e.g. -3 will serve 3 tuples)
     },
 
+    // realtime notification settings
+    "push": [
+        {
+            "url": "http://127.0.0.1:5582"  // notification destination, e.g. frontend push-server
+        }
+    ],
+
     // Meter configuration
     "meters": [
         {


### PR DESCRIPTION
Provide better readability and more consistent comments.

Note: `D0` still has this apparently wrong line:

            "interval": 6,                  // Wartezeit in Sekunden bis neue Werte in die middleware übertragen werden

Would appreciate feedback how to describe `interval` and where it actually applies.