### PR TITLE
fix identifier parsing for w1_therm

### DIFF
--- a/src/Reading.cpp
+++ b/src/Reading.cpp
@@ -117,6 +117,7 @@ ReadingIdentifier::Ptr reading_id_parse(meter_protocol_t protocol, const char *s
 			case meter_protocol_exec:
 			case meter_protocol_s0:
 			case meter_protocol_ocr:
+			case meter_protocol_w1therm:
 				rid = ReadingIdentifier::Ptr(new StringIdentifier(string));
 				break;
 


### PR DESCRIPTION
Thanks to @Udo 's test here a fix for the 1wire implementation. (Next time I'd better test whether the data actually arrives at the middleware...) 