### PR TITLE
added code coverage analysis for unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,6 @@ before_install:
   - ./build.sh
   - sudo make install
   - cd ..
-
+  - sudo apt-get install lcov
 script:
   - cmake . -DENABLE_OCR=ON -DSML_HOME=/usr/local/src/libsml/sml && make && make test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,6 @@ ADD_DEFINITIONS(-g3)
 # Where are the additional libraries installed? Note: provide includes
 # path here, subsequent checks will resolve everything else
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/modules")
-include (UseCodeCoverage)
 
 # get git sha1 as additional version:
 include(GetGitRevisionDescription)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -48,4 +48,47 @@ if(SML_FOUND)
   target_link_libraries(vzlogger_unit_tests ${SML_LIBRARY})
 endif(SML_FOUND)
 
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fprofile-arcs -ftest-coverage")
+
 add_subdirectory(mocks)
+
+FIND_PROGRAM( GCOV_PATH gcov )
+FIND_PROGRAM( LCOV_PATH lcov )
+FIND_PROGRAM( GENHTML_PATH genhtml )
+
+IF(GCOV_PATH AND LCOV_PATH AND GENHTML_PATH)
+	MESSAGE("gcov found. Adding target test_coverage ...")
+
+# Setup target for coverage
+# we need to add each single test binary into the command list
+
+ADD_CUSTOM_TARGET(test_coverage
+
+		# Cleanup lcov
+		${LCOV_PATH} --rc lcov_branch_coverage=1 --directory . --zerocounters
+
+		# Run tests
+		COMMAND vzlogger_unit_tests
+		COMMAND mock_metermap
+		COMMAND mock_MeterW1therm
+		COMMAND mock_MeterOMS
+		COMMAND mock_MeterS0
+
+		# Capturing lcov counters and generating report
+		COMMAND ${LCOV_PATH} --rc lcov_branch_coverage=1 --directory . --capture --output-file coverage.info
+		COMMAND ${LCOV_PATH} --rc lcov_branch_coverage=1 --remove coverage.info 'tests/*' '/usr/*' --output-file coverage.info.cleaned
+		COMMAND ${GENHTML_PATH} --rc lcov_branch_coverage=1 -o coverage coverage.info.cleaned
+		COMMAND ${CMAKE_COMMAND} -E remove coverage.info coverage.info.cleaned
+
+		WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+		COMMENT "Resetting code coverage counters to zero.\nProcessing code coverage counters and generating report."
+	)
+
+	# Show info where to find the report
+	ADD_CUSTOM_COMMAND(TARGET test_coverage POST_BUILD
+		COMMAND ;
+		COMMENT "Open ./coverage/index.html in your browser to view the coverage report."
+	)
+
+ENDIF() # NOT GCOV_PATH
+

--- a/tests/mocks/CMakeLists.txt
+++ b/tests/mocks/CMakeLists.txt
@@ -118,3 +118,5 @@ target_link_libraries(mock_MeterS0
 )
 add_test(mock_MeterS0 mock_MeterS0)
 
+# ensure that all test binaries are added to tests/CMakeLists.txt test_coverage target
+# (or find a better way to add them from here to the test_coverage target


### PR DESCRIPTION
Added code coverage analysis (line-, function- and branch-) using gcov/lcov for all unit tests and mocks.
A new make target "test_coverage" will be added only if gcov, lcov and genhtml are available.
Coverage results will be in ./coverage/index.html.
(Current overall values: 54.5% line, 55.4% function and 25.5% branch coverage.)

(I'm just not sure whether vzlogger is now build with profiling support as well. This should be double-checked. (I checked and didn't find any coverage data being generated if e.g. vzlogger -V is called.) 