### PR TITLE
added clean-all target to remove some cmake generated files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -221,6 +221,12 @@ INSTALL(FILES README COPYING DESTINATION
   share/doc/vzlogger-${VZLOGGER_MAJOR_VERSION}-${VZLOGGER_MINOR_VERSION}
 )
 
+# add clean-all target that removes the cached files from cmake as well (see e.g. issue #186)
+add_custom_target(clean-all
+    COMMAND ${CMAKE_BUILD_TOOL} clean
+    COMMAND ${CMAKE_COMMAND} -P clean-all-cmake.txt
+)
+
 # CPACK packaging
 INCLUDE(InstallRequiredSystemLibraries)
 set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS On)

--- a/clean-all-cmake.txt
+++ b/clean-all-cmake.txt
@@ -1,0 +1,16 @@
+# will be called if make clean-all is called (after make clean)
+# afterwards "make" doesn't work anylonger -> "cmake ."
+
+set(cmake_generated ${CMAKE_BINARY_DIR}/CMakeCache.txt
+                    ${CMAKE_BINARY_DIR}/cmake_install.cmake
+                    ${CMAKE_BINARY_DIR}/Makefile
+                    ${CMAKE_BINARY_DIR}/CMakeFiles
+)
+
+foreach(file ${cmake_generated})
+  if (EXISTS ${file})
+     file(REMOVE_RECURSE ${file})
+  endif()
+endforeach(file)
+
+MESSAGE ( STATUS "removed CMakeCache.txt, cmake_install.cmake, MakeFiles and CMakeFiles. Recreate by calling cmake." )


### PR DESCRIPTION
see #186. Removing CMakeCache.txt and some more cake files.
Call by 
```
make clean-all
```
Can only be called once afterwards a "cmake ." is needed. Calls "make clean" automatically.

Btw: we should change to "out-of-source" builds. E.g. 
```
cd vzlogger
mkdir build
cmake ..
```
instead of calling cmake . in source dir.