### PR TITLE
added fix for s0, send_zero=true, blocking hw_if

### DIFF
--- a/include/protocols/MeterS0.hpp
+++ b/include/protocols/MeterS0.hpp
@@ -34,6 +34,7 @@
 
 // some helper functions. might need a namespace
 void timespec_sub(const struct timespec &a, const struct timespec &b, struct timespec &res);
+void timespec_add(struct timespec &a, const struct timespec &b); // a+=b
 void timespec_add_ms(struct timespec &a, unsigned long ms);
 unsigned long timespec_sub_ms(const struct timespec &a, const struct timespec &b);
 


### PR DESCRIPTION
Fixes wrong time returned for S0 when send_zero is activated and blocking hw_if is used.
Add a unit test for that case as well.