### PR TITLE
Remove deprecated libmicrohttpd functions. #246

### DIFF
--- a/src/local.cpp
+++ b/src/local.cpp
@@ -212,7 +212,7 @@ int handle_request(
 			}
 
 			json_str = json_object_to_json_string(json_obj);
-			response = MHD_create_response_from_data(strlen(json_str), (void *) json_str, FALSE, TRUE);
+			response = MHD_create_response_from_buffer(strlen(json_str), static_cast<void *>(const_cast<char *> (json_str)), MHD_RESPMEM_MUST_COPY);
 			json_object_put(json_obj);
 
 			MHD_add_response_header(response, "Content-type", "application/json");
@@ -220,7 +220,7 @@ int handle_request(
 		else {
 			char *response_str = strdup("not implemented\n");
 
-			response = MHD_create_response_from_data(strlen(response_str), (void *) response_str, TRUE, FALSE);
+			response = MHD_create_response_from_buffer(strlen(response_str), static_cast<void *>(const_cast<char *> (response_str)), MHD_RESPMEM_MUST_COPY);
 			response_code = MHD_HTTP_METHOD_NOT_ALLOWED;
 
 			MHD_add_response_header(response, "Content-type", "text/text");


### PR DESCRIPTION
```
zobel@kvasir` ~ % dpkg -l | grep microhttpd          
ii  libmicrohttpd-dev                             0.9.44+dfsg-1+b2                    amd64        library embedding HTTP server functionality (development)
ii  libmicrohttpd10                               0.9.44+dfsg-1+b2                    amd64        library embedding HTTP server functionality
zobel@kvasir ~ % 

```

Looking at the build log, the CI system is using a way older version of the library:
[https://travis-ci.org/volkszaehler/vzlogger/jobs/118366414#L756](https://travis-ci.org/volkszaehler/vzlogger/jobs/118366414#L756)

I am pretty sure though, once the CI system is upgraded to trusty, the builds will break too:

```
zobel@kvasir ~ % rmadison -a amd64 -u debian libmicrohttpd-dev
libmicrohttpd-dev | 0.9.20-1+deb7u1  | oldstable  | amd64
libmicrohttpd-dev | 0.9.37+dfsg-1+b1 | stable     | amd64
libmicrohttpd-dev | 0.9.44+dfsg-1+b2 | testing    | amd64
libmicrohttpd-dev | 0.9.44+dfsg-1+b2 | unstable   | amd64
zobel@kvasir ~ % rmadison -a amd64 -u ubuntu libmicrohttpd-dev
libmicrohttpd-dev | 0.4.6-1              | precise/universe | amd64
libmicrohttpd-dev | 0.9.33-1             | trusty/universe  | amd64
libmicrohttpd-dev | 0.9.37+dfsg-1build1  | vivid/universe   | amd64
libmicrohttpd-dev | 0.9.37+dfsg-1ubuntu1 | wily/universe    | amd64
libmicrohttpd-dev | 0.9.44+dfsg-1ubuntu2 | xenial           | amd64
zobel@kvasir ~ % 
```