### PR TITLE
change travis-ci to use dist trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+sudo: required
+dist: trusty
+
 language: cpp
 
 compiler: 
@@ -10,11 +13,11 @@ env:
 before_install:
   - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
   - sudo apt-get update -qq
-  - if [ "$CXX" = "g++" ]; then sudo apt-get install -qq g++-4.8; export CXX="g++-4.8" CC="gcc-4.8"; else echo "yes" | sudo add-apt-repository 'deb http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu precise main'; echo "yes" | sudo add-apt-repository 'deb http://llvm.org/apt/precise/ llvm-toolchain-precise-3.6 main'; wget -O - http://llvm.org/apt/llvm-snapshot.gpg.key | sudo apt-key add -; sudo apt-get update; sudo apt-get install -qq --allow-unauthenticated llvm-3.6 llvm-3.6-dev clang-3.6 libstdc++-4.8-dev; export CXX="clang++-3.6" CC="clang-3.6"; fi
+# uncomment for ubuntu precise. not needed for >=trusty - if [ "$CXX" = "g++" ]; then sudo apt-get install -y -qq g++-4.8; export CXX="g++-4.8" CC="gcc-4.8"; else echo "yes" | sudo add-apt-repository 'deb http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu precise main'; echo "yes" | sudo add-apt-repository 'deb http://llvm.org/apt/precise/ llvm-toolchain-precise-3.6 main'; wget -O - http://llvm.org/apt/llvm-snapshot.gpg.key | sudo apt-key add -; sudo apt-get update; sudo apt-get install -qq --allow-unauthenticated llvm-3.6 llvm-3.6-dev clang-3.6 libstdc++-4.8-dev; export CXX="clang++-3.6" CC="clang-3.6"; fi
 # install json-c
-  - sudo apt-get install build-essential
-  - sudo apt-get install wget
-  - sudo apt-get install libtool
+  - sudo apt-get install -y build-essential
+  - sudo apt-get install -y wget
+  - sudo apt-get install -y libtool
   - git clone -b json-c-0.12 https://github.com/json-c/json-c
   - cd json-c
   - sh autogen.sh
@@ -35,7 +38,7 @@ before_install:
   - cd ..
 
 # -- install leptonica
-  - sudo apt-get install libpng-dev libtiff-dev
+  - sudo apt-get install -y libpng-dev libtiff-dev
   - wget http://www.leptonica.org/source/leptonica-1.71.tar.gz
   - tar -zxvf leptonica-1.71.tar.gz
   - cd leptonica-1.71
@@ -51,6 +54,6 @@ before_install:
   - ./build.sh
   - sudo make install
   - cd ..
-  - sudo apt-get install lcov
+  - sudo apt-get install -y lcov
 script:
   - cmake . -DENABLE_OCR=ON -DSML_HOME=/usr/local/src/libsml/sml && make && make test


### PR DESCRIPTION
With this change travis-ci will use ubuntu trusty and not precise any longer.
See e.g. #246 #247.
If we merge this we basically don't support ubuntu precise any longer as we can't really test against it. So not actively breaking it but not being able to detect future breakages.
Anyhow I'd vote for updating to trusty.