### PR TITLE
Add per-channel log interval scaling

### DIFF
--- a/etc/vzlogger.conf
+++ b/etc/vzlogger.conf
@@ -65,7 +65,11 @@
             }, {
                 "uuid": "d5c6db0f-533e-498d-a85a-be972c104b48",
                 "middleware": "http://localhost/middleware.php",
-                "identifier": "1-0:1.8.0"   // OBIS identifier
+                "identifier": "1-0:1.8.0",  // OBIS identifier
+                "interval_factor": 300      // Log only every 300th reading. Use this to reduce data on slowly changing channels.
+                                            // E.g. energy counters. This nicely reduces glitches caused by small energy
+                                            // differences in the default log interval (consider energy in Wh logged every second).
+
             }]
         },
         {

--- a/include/Channel.hpp
+++ b/include/Channel.hpp
@@ -92,6 +92,10 @@ class Channel {
 
 	int duplicates() const { return _duplicates; }
 
+	int interval_div(int inc);
+
+	int interval_factor() const { return _interval_factor; }
+
 	private:
 	static int instances;
 	bool _thread_running;   	// flag if thread is started
@@ -111,6 +115,8 @@ class Channel {
 	std::string _uuid;			// unique identifier for middleware
 	std::string _apiProtocol;	// protocol of api to use for logging
 	int _duplicates;			// how to handle duplicate values (see conf)
+	int _interval_factor;		// log this channel only every interval_factor
+	int _interval_cnt;
 };
 
 #endif /* _CHANNEL_H_ */

--- a/src/threads.cpp
+++ b/src/threads.cpp
@@ -103,21 +103,27 @@ void * reading_thread(void *arg) {
 
 					for (size_t i = 0; i < n; i++) {
 						if (*rds[i].identifier().get() == *(*ch)->identifier().get()) {
-							//print(log_debug, "found channel", mtr->name());
-							if ((*ch)->time_ms() < rds[i].time_ms()) {
-								(*ch)->last(&rds[i]);
-							}
+							int div = (*ch)->interval_div(1);
+							if (div == 0) {
+								//print(log_debug, "found channel", mtr->name());
+								if ((*ch)->time_ms() < rds[i].time_ms()) {
+									(*ch)->last(&rds[i]);
+								}
 
-							print(log_info, "Adding reading to queue (value=%.2f ts=%lld)", (*ch)->name(),
-									rds[i].value(), rds[i].time_ms());
-							(*ch)->push(rds[i]);
-
+								print(log_info, "Adding reading to queue (value=%.2f ts=%lld)", (*ch)->name(),
+										rds[i].value(), rds[i].time_ms());
+								(*ch)->push(rds[i]);
 							// provide data to push data server:
 							if (pushDataList) {
 								const std::string uuid = (*ch)->uuid();
 								pushDataList->add(uuid, rds[i].time_ms(), rds[i].value());
 								print(log_finest, "added to uuid %s", "push", uuid.c_str());
 							}
+							} else {
+								print(log_info, "Skipping [%d/%d] reading    (value=%.2f ts=%lld)", (*ch)->name(),
+										div, (*ch)->interval_factor(), rds[i].value(), rds[i].time_ms());
+							}
+
 
 							if (add == NULL) {
 								add = &rds[i]; /* remember first reading which has been added to the buffer */


### PR DESCRIPTION
Add a channel option to multiply the meter's logging interval
and send only every X'th value to the middleware.
This can be used to reduce data on slowly changing channels, e.g.
energy counters. This nicely reduces glitches caused by small energy
differences in the default log interval
(consider energy in Wh logged every second).