### PR TITLE
Influx REST call: use least possible timestamp precision

### DIFF
--- a/src/api/InfluxDB.cpp
+++ b/src/api/InfluxDB.cpp
@@ -98,7 +98,7 @@ vz::api::InfluxDB::InfluxDB(
 
 	try {
 			_measurement_name = optlist.lookup_string(pOptions, "measurement_name");
-			print(log_finest, "api InfluxDB using measurement name %s", ch->name(), _database.c_str());
+			print(log_finest, "api InfluxDB using measurement name %s", ch->name(), _measurement_name.c_str());
 		} catch (vz::OptionNotFoundException &e) {
 			print(log_finest, "api InfluxDB will use default measurement name \"vzlogger\"", ch->name());
 			_measurement_name = "vzlogger";
@@ -145,6 +145,7 @@ vz::api::InfluxDB::InfluxDB(
 	_url.append("/write");
 	_url.append("?db=");
 	_url.append(_database);
+	_url.append("&precision=ms");
 	print(log_debug, "api InfluxDB using url %s", ch->name(), _url.c_str());
 
 }
@@ -201,7 +202,7 @@ void vz::api::InfluxDB::send()
 		request_body.append(std::to_string(it->value()));
 		request_body.append(" ");
 		request_body.append(std::to_string(it->time_ms()));
-		request_body.append("000000\n"); // needed for correct InfluxDB timestamp, each measurement on new line
+		request_body.append("\n"); // each measurement on new line
 		it->mark_delete();
 		request_body_lines++;
 	}

--- a/src/api/InfluxDB.cpp
+++ b/src/api/InfluxDB.cpp
@@ -140,14 +140,23 @@ vz::api::InfluxDB::InfluxDB(
 			throw;
 		}
 
+	CURL *curlhelper = curl_easy_init();
+	if(!curlhelper) {
+		throw vz::VZException("CURL: cannot create handle for urlencode.");
+	}
+	char *database_urlencoded = curl_easy_escape(curlhelper, _database.c_str(), 0);
+	if(!database_urlencoded) {
+		throw vz::VZException("Cannot url-encode database name.");
+	}
+
 	// build request url
 	_url = _host;
 	_url.append("/write");
 	_url.append("?db=");
-	_url.append(_database);
+	_url.append(database_urlencoded);
 	_url.append("&precision=ms");
 	print(log_debug, "api InfluxDB using url %s", ch->name(), _url.c_str());
-
+	curl_free(database_urlencoded);
 }
 
 vz::api::InfluxDB::~InfluxDB() // destructor


### PR DESCRIPTION
ms instead of ns, as recommended by InfluxDB documentation.
Fix: Corrected logging message for measurement name

2nd try. Had to reset my repository, therefore the previous pull request disappeared, together with the thread.

This PR only got the timestamp precision change as recommended at https://docs.influxdata.com/influxdb/v1.3/tools/api/#query-string-parameters-2

Due to recommendation from @andig I worked on url-encoding _database. It turned out the _measurement_name is also not url-encoded.

I have code for this which compiles, but need to test it first. 

Meanwhile consider this PR WIP. Just recreated it due to me resetting my repo. Will update as soon as my tests conclude.