### PR TITLE
fix compilation with openssl 1.1

### DIFF
--- a/src/protocols/MeterOMS.cpp
+++ b/src/protocols/MeterOMS.cpp
@@ -142,7 +142,9 @@ MeterOMS::MeterOMS(const std::list<Option> &options, OMSHWif *hwif) :
 	// init openssl:
 	ERR_load_crypto_strings();
 	OpenSSL_add_all_algorithms();
-	OPENSSL_config(NULL);
+#if OPENSSL_API_COMPAT < 0x10100000L
+	OPENSSL_config(NULL); // not needed anylonger with current openssl versions
+#endif
 
 	// parse options:
 	// expect device and key

--- a/src/protocols/MeterOMS.cpp
+++ b/src/protocols/MeterOMS.cpp
@@ -140,10 +140,14 @@ MeterOMS::MeterOMS(const std::list<Option> &options, OMSHWif *hwif) :
 	print(log_debug, "Using libmbus version %s", name().c_str(), mbus_get_current_version());
 
 	// init openssl:
+#if OPENSSL_VERSION_NUMBER >= 0x10100003L
+	OPENSSL_init_ssl(OPENSSL_INIT_LOAD_CONFIG, NULL);
+	ERR_load_crypto_strings();
+	OpenSSL_add_all_algorithms(); // should be called after init
+#else
 	ERR_load_crypto_strings();
 	OpenSSL_add_all_algorithms();
-#if OPENSSL_API_COMPAT < 0x10100000L
-	OPENSSL_config(NULL); // not needed anylonger with current openssl versions
+	OPENSSL_config(NULL);
 #endif
 
 	// parse options:

--- a/src/protocols/MeterOMS.cpp
+++ b/src/protocols/MeterOMS.cpp
@@ -13,6 +13,7 @@
 #include <openssl/conf.h>
 #include <openssl/evp.h>
 #include <openssl/err.h>
+#include <openssl/ssl.h>
 #include "protocols/MeterOMS.hpp"
 
 // send_frame: similar to mbus_serial_send_frame from libmbus!


### PR DESCRIPTION
Should fix #322 . According to OPENSLL docs OPENSSL_config is no longer needed with v1.1.
Untested!