### PR TITLE
use right package name for libmicrohttpd in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ For Debian Jessie be sure to add:
 For Debian Stretch use:
 
     sudo apt-get install git cmake autoconf libtool uuid-dev libcurl4-openssl-dev libssl-dev \
-      libgnutls28-dev libgcrypt20-dev libmicrohttp-dev libsasl2-dev
+      libgnutls28-dev libgcrypt20-dev libmicrohttpd-dev libsasl2-dev
 
 Then run the installation:
 


### PR DESCRIPTION
it was missing the `d`