### PR TITLE
fix cross-compiling

### DIFF
--- a/modules/CompilerFlags.cmake
+++ b/modules/CompilerFlags.cmake
@@ -102,11 +102,23 @@ else(NOT WIN32)
 endif(NOT WIN32)
 
 # check for specific c++ features:
-include(CheckCXXSourceRuns)
-check_cxx_source_runs("
-      #include <regex>
+if(CMAKE_CROSSCOMPILING)
+	include(CheckCXXSourceCompiles)
+	check_cxx_source_compiles("
+		  #include <regex>
 
-      int main() {
-        return std::regex_match(\"test\", std::regex(\"\^\\\\\\\\s*(//(.*|)|\$)\"));
-      }
-" HAVE_CPP_REGEX)
+		  int main() {
+		    return std::regex_match(\"test\", std::regex(\"\^\\\\\\\\s*(//(.*|)|\$)\"));
+		  }
+	" HAVE_CPP_REGEX )
+else(CMAKE_CROSSCOMPILING)
+	include(CheckCXXSourceRuns)
+	check_cxx_source_runs("
+		  #include <regex>
+
+		  int main() {
+		    return std::regex_match(\"test\", std::regex(\"\^\\\\\\\\s*(//(.*|)|\$)\"));
+		  }
+	" HAVE_CPP_REGEX)
+endif(CMAKE_CROSSCOMPILING)
+


### PR DESCRIPTION
The cmake module 'CompilerFlags' trys to run some build output, which
doesn't work in cross-compiling mode (for example building on a x86 host
we cannot run ARM binaries there).

We modify therefore the check in case of cross-compiling into a simple
"does-compile" check rather then try running the binary.

Behaviour on native build ist the same as before.

Signed-off-by: Hannes Schmelzer <oe5hpm@oevsv.at>