### PR TITLE
gcc 7 fixes and travis-ci build target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,12 +8,19 @@ compiler:
     - gcc
 
 env:
-  - CTEST_OUTPUT_ON_FAILURE=1
+  - CTEST_OUTPUT_ON_FAILURE=1 USE_GCC7=0
+  - CTEST_OUTPUT_ON_FAILURE=1 USE_GCC7=1
+
+matrix:
+  exclude:
+  - compiler: clang
+    env: CTEST_OUTPUT_ON_FAILURE=1 USE_GCC7=1
 
 before_install:
   - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
   - sudo apt-get update -qq
 # uncomment for ubuntu precise. not needed for >=trusty - if [ "$CXX" = "g++" ]; then sudo apt-get install -y -qq g++-4.8; export CXX="g++-4.8" CC="gcc-4.8"; else echo "yes" | sudo add-apt-repository 'deb http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu precise main'; echo "yes" | sudo add-apt-repository 'deb http://llvm.org/apt/precise/ llvm-toolchain-precise-3.6 main'; wget -O - http://llvm.org/apt/llvm-snapshot.gpg.key | sudo apt-key add -; sudo apt-get update; sudo apt-get install -qq --allow-unauthenticated llvm-3.6 llvm-3.6-dev clang-3.6 libstdc++-4.8-dev; export CXX="clang++-3.6" CC="clang-3.6"; fi
+  - if [ "$USE_GCC7" = "1" ]; then sudo apt-get install -y -qq g++-7; export CXX="g++-7" CC="gcc-7"; fi
 # install json-c
   - sudo apt-get install -y build-essential
   - sudo apt-get install -y wget

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,11 +21,12 @@ before_install:
   - sudo apt-get update -qq
 # uncomment for ubuntu precise. not needed for >=trusty - if [ "$CXX" = "g++" ]; then sudo apt-get install -y -qq g++-4.8; export CXX="g++-4.8" CC="gcc-4.8"; else echo "yes" | sudo add-apt-repository 'deb http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu precise main'; echo "yes" | sudo add-apt-repository 'deb http://llvm.org/apt/precise/ llvm-toolchain-precise-3.6 main'; wget -O - http://llvm.org/apt/llvm-snapshot.gpg.key | sudo apt-key add -; sudo apt-get update; sudo apt-get install -qq --allow-unauthenticated llvm-3.6 llvm-3.6-dev clang-3.6 libstdc++-4.8-dev; export CXX="clang++-3.6" CC="clang-3.6"; fi
   - if [ "$USE_GCC7" = "1" ]; then sudo apt-get install -y -qq g++-7; export CXX="g++-7" CC="gcc-7"; fi
+  - $CXX --version
 # install json-c
   - sudo apt-get install -y build-essential
   - sudo apt-get install -y wget
   - sudo apt-get install -y libtool
-  - git clone -b json-c-0.12 https://github.com/json-c/json-c
+  - git clone -b json-c-0.12 https://github.com/mbehr1/json-c
   - cd json-c
   - sh autogen.sh
   - ./configure

--- a/src/api/MySmartGrid.cpp
+++ b/src/api/MySmartGrid.cpp
@@ -598,7 +598,7 @@ void vz::api::MySmartGrid::hmac_sha1(
 
 	for (size_t i=0; i<len; i++) {
 		char s[4];
-		snprintf(s, 3, "%02x:", out[i]);
+        snprintf(s, 3, "%02x", out[i]); // format string was "%02x:" but size was only 3 so last : was not printed
 		strncat(ret, s, 2*len);
 //strncat(ret, s, sizeof(ret));
 	}

--- a/src/protocols/MeterExec.cpp
+++ b/src/protocols/MeterExec.cpp
@@ -90,7 +90,7 @@ MeterExec::MeterExec(std::list<Option> options)
 
 					case '%':
 						scanf_format[j++] = '%'; // add double %% to escape a conversion identifier
-						// nobreak;
+                        // fallthrough
 					default:
 						scanf_format[j++] = config_format[i]; // just copying
 			}

--- a/src/protocols/MeterFile.cpp
+++ b/src/protocols/MeterFile.cpp
@@ -79,7 +79,7 @@ MeterFile::MeterFile(std::list<Option> options)
 
 					case '%':
 						scanf_format[j++] = '%'; // add double %% to escape a conversion identifier
-						// nobreak;
+                        // fallthrough
 					default:
 						scanf_format[j++] = config_format[i]; // just copying
 			}


### PR DESCRIPTION
As a fix for #315 I provide:
- fixes in vzlogger
 - basically just comments // fallthrough
 - one snprintf error for MySmartGrip API. That should be double checked. Previously due to the len 3 the : from the "%02x:" wasn't printed. So I removed that.
- fixes in json-c -> I forked it, corrected it and use it for travis-ci
- added new build for travis ci that uses gcc-7