### PR TITLE
add BUILD_TEST option for disabling unit-tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,6 +70,10 @@ OPTION(METEREXEC_ROOTACCESS
   "compile MeterExec protocol to use root privileges for script calls (def=no)])"
   Off)
 
+OPTION(BUILD_TEST
+  "build unit tests (def=on)])"
+  On)
+
 # find dependencies
 # libsml
 if( ENABLE_SML )
@@ -164,7 +168,12 @@ add_subdirectory(src)
 
 find_package(Git)
 
-set(ENABLE_GOOGLEMOCK TRUE)
+if( BUILD_TEST )
+	set(ENABLE_GOOGLEMOCK TRUE)
+else()
+	set(ENABLE_GOOGLEMOCK FALSE)
+endif()
+
 #disable unit tests on gcc4.6 (problems with googlemock 1.7)
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
     # require at least gcc 4.8


### PR DESCRIPTION
During cross-compiling with some buildsystem (buildroot for example) we
have no possibility to run the implemented unit tests. This well known
fact is handled by the build system by passing several variables to the
running build, one of these is the "BUILD_TEST".

We use this for enabling/disabling building the unit tests.

Per default the BUILD_TEST is on, so no functional change to previous
versions is made.

Signed-off-by: Hannes Schmelzer <oe5hpm@oevsv.at>