### PR TITLE
S0 via UART: Baudrate

### DIFF
--- a/src/protocols/MeterS0.cpp
+++ b/src/protocols/MeterS0.cpp
@@ -463,7 +463,7 @@ bool MeterS0::HWIF_UART::_open()
 	struct termios tio;
 	memset(&tio, 0, sizeof(struct termios));
 
-	tio.c_cflag = B300 | CS8 | CLOCAL | CREAD;
+	tio.c_cflag = B9600 | CS8 | CLOCAL | CREAD;
 	tio.c_iflag = IGNPAR;
 	tio.c_oflag = 0;
 	tio.c_lflag = 0;


### PR DESCRIPTION
Erhöhung der maximalen Impulsfrequenz bei S0 via UART durch Erhöhung der Baudrate
Diskussion: http://lists.volkszaehler.org/pipermail/volkszaehler-users/2018-January/011615.html