### PR TITLE
Add optional "tags" when inserting data to InfluxDB

### DIFF
--- a/etc/vzlogger.conf.InfluxDB
+++ b/etc/vzlogger.conf.InfluxDB
@@ -25,6 +25,7 @@
                 "host": "127.0.0.1:8086",                       // This assumes that InfluxDB is running on localhost
                 //"database": "vzlogger",                       // Optional: make sure this database exists in InfluxDB
                 //"measurement_name": "vz_measurement",         // Optional: It is recommended that all your meters have the same InfluxDB measurement name
+                //"tags": "foo=bar,example=42",                 // Optional: Additional tags to append when inserting data
                 //"username": "example",                        // Optional: When InfluxDB Auth is enabled you need to set the correct user and password
                 //"password": "secure",
                 //"max_batch_inserts": 4500,                    // Optional: Max number of measurements per request. No need to change this

--- a/include/api/InfluxDB.hpp
+++ b/include/api/InfluxDB.hpp
@@ -59,6 +59,7 @@ namespace vz {
 			std::string _password;
 			std::string _database;
 			std::string _measurement_name;
+			std::string _tags;
 			std::string _url;
 			int _max_batch_inserts;
 			int _max_buffer_size;

--- a/src/api/InfluxDB.cpp
+++ b/src/api/InfluxDB.cpp
@@ -108,6 +108,17 @@ vz::api::InfluxDB::InfluxDB(
 		}
 
 	try {
+			_tags = optlist.lookup_string(pOptions, "tags");
+			print(log_finest, "api InfluxDB using tags %s", ch->name(), _tags.c_str());
+		} catch (vz::OptionNotFoundException &e) {
+			print(log_finest, "api InfluxDB will not use any tags", ch->name());
+			_tags = "";
+		} catch (vz::VZException &e) {
+			print(log_alert, "api InfluxDB requires parameter \"tags\" as string!", ch->name());
+			throw;
+		}
+
+	try {
 			_curl_timeout = optlist.lookup_int(pOptions, "timeout");
 			print(log_finest, "api InfluxDB using curl timeout %i", ch->name(), _curl_timeout);
 		} catch (vz::OptionNotFoundException &e) {
@@ -207,6 +218,10 @@ void vz::api::InfluxDB::send()
 		request_body.append(_measurement_name);
 		request_body.append(",uuid=");
 		request_body.append(channel()->uuid());
+		if (!_tags.empty()) {
+			request_body.append(",");
+			request_body.append(_tags);
+		}
 		request_body.append(" value=");
 		request_body.append(std::to_string(it->value()));
 		request_body.append(" ");


### PR DESCRIPTION
InfluxDB now accepts option "tags" where one can add optional tags when inserting data.
```
time                uuid                                 value
----                ----                                 -----
1520253111070000000 01234567-9abc-def0-1234-56789abcdefe 21.280788
1520253113071000000 955c0180-7212-4ec8-a37e-47c834e9af77 20.76071
1520253115071000000 01234567-9abc-def0-1234-56789abcdefe 19.309906
```
->
```
time                meter  location uuid                                 value
----                ---    ----     ----                                 -----
1520253111070000000 main   home     01234567-9abc-def0-1234-56789abcdefe 21.280788
1520253113071000000 second home     955c0180-7212-4ec8-a37e-47c834e9af77 20.76071
1520253115071000000 main   home     01234567-9abc-def0-1234-56789abcdefe 19.309906
```

This helps identifying the data in Influx as UUIDs are quite hard to remember.

Accepts an arbitrary number of tags as it's just a string concatenated to the query. Maybe there's a better way for the config file. Instead of
```
"channels": [{
    "api": "influxdb",
    "uuid": "01234567-9abc-def0-1234-56789abcdefe",
    "identifier" : "1-0:16.7.0",
    "host": "127.0.0.1:8086",
    "tags": "meter=main,location=home",
}]
```
maybe
```
"channels": [{
    "api": "influxdb",
    "uuid": "01234567-9abc-def0-1234-56789abcdefe",
    "identifier" : "1-0:16.7.0",
    "host": "127.0.0.1:8086",
    "tags": {
        "meter": "main",
        "location": "home"
    }
}]
```