### PR TITLE
Ubuntu1804 build fixes due to missing libunistring-dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ before_install:
   - make
   - sudo make install
   - cd ..
-  - sudo apt-get install -y libcurl4-openssl-dev openssl libmicrohttpd-dev uuid-dev uuid-runtime
+  - sudo apt-get install -y libcurl4-openssl-dev openssl libmicrohttpd-dev uuid-dev uuid-runtime libunistring-dev
 # -- get libsml --
   - git clone https://github.com/volkszaehler/libsml.git # or github.com/TheCount/libsml.git # or https://github.com/dailab/libsml.git
   - cd libsml 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ For Debian Stretch use:
     sudo apt-get install git cmake autoconf libtool uuid-dev libcurl4-openssl-dev libssl-dev \
       libgnutls28-dev libgcrypt20-dev libmicrohttpd-dev libsasl2-dev
 
+Ubuntu 18.04LTS (bionic) needs an additional:
+
+   sudo apt-get install libunistring-dev
+(this might be needed on others now as well as we link unconditionally against libunistring)
+
 Then run the installation:
 
     wget --no-check-certificate https://raw.github.com/volkszaehler/vzlogger/master/install.sh

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -70,7 +70,7 @@ if( TARGET )
     target_link_libraries(vzlogger dl)
   endif( ${TARGET} STREQUAL "ar71xx")
 endif( TARGET )
-target_link_libraries(vzlogger ${CURL_STATIC_LIBRARIES} ${CURL_LIBRARIES} ${GNUTLS_LIBRARIES} ${OPENSSL_LIBRARIES} )
+target_link_libraries(vzlogger ${CURL_STATIC_LIBRARIES} ${CURL_LIBRARIES} unistring ${GNUTLS_LIBRARIES} ${OPENSSL_LIBRARIES} )
 
 # add programs to the install target 
 INSTALL(PROGRAMS 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -38,7 +38,7 @@ target_link_libraries(vzlogger_unit_tests
     ${LIBUUID}
     dl
     pthread)
-target_link_libraries(vzlogger_unit_tests ${CURL_STATIC_LIBRARIES} ${CURL_LIBRARIES} ${GNUTLS_LIBRARIES} ${OCR_LIBRARIES})
+target_link_libraries(vzlogger_unit_tests ${CURL_STATIC_LIBRARIES} ${CURL_LIBRARIES} unistring ${GNUTLS_LIBRARIES} ${OCR_LIBRARIES})
 
 if( OMS_SUPPORT )
 target_link_libraries(vzlogger_unit_tests ${MBUS_LIBRARY} ${OPENSSL_LIBRARIES})

--- a/tests/MeterD0.cpp
+++ b/tests/MeterD0.cpp
@@ -280,7 +280,22 @@ TEST(MeterD0, LandisGyr_basic) {
 	EXPECT_EQ(0, unlink(tempfilename));
 }
 
-int writes_hex(int fd, const char *str);
+int writes_hex(int fd, const char *str)
+{
+        int toret=0;
+        // expect each string as a hexdump. two chars for each byte:
+        int len = strlen(str);
+        EXPECT_EQ(0, len%2); // strlen should be even.
+        for (int i=0; i<len; i+=2){
+                unsigned char c;
+                sscanf(&str[i], "%2hhx", &c);
+                int r = write(fd, &c, 1);
+                if (r==-1) return r;
+                toret += r;
+        }
+        return toret;
+}
+
 
 TEST(MeterD0, ACE3000_basic) {
 	char tempfilename[L_tmpnam+1];

--- a/tests/MeterSML.cpp
+++ b/tests/MeterSML.cpp
@@ -12,21 +12,7 @@
 
 #include "../src/protocols/MeterSML.cpp"
 
-int writes_hex(int fd, const char *str)
-{
-	int toret=0;
-	// expect each string as a hexdump. two chars for each byte:
-	int len = strlen(str);
-	EXPECT_EQ(0, len%2); // strlen should be even.
-	for (int i=0; i<len; i+=2){
-		unsigned char c;
-		sscanf(&str[i], "%2hhx", &c);
-		int r = write(fd, &c, 1);
-		if (r==-1) return r;
-		toret += r;
-	}
-	return toret;
-}
+int writes_hex(int fd, const char *str); // impl. in MeterD0.cpp
 
 TEST(MeterSML, EMH_basic) {
 	char tempfilename[L_tmpnam+1];

--- a/tests/mocks/CMakeLists.txt
+++ b/tests/mocks/CMakeLists.txt
@@ -10,6 +10,11 @@ elseif( OMS_SUPPORT )
   set(mock_oms_sources "")
 endif( OMS_SUPPORT )
 
+if(SML_FOUND)
+  set(mock_sml_sources ../../src/protocols/MeterSML.cpp)
+elseif(SML_FOUND)
+  set(mock_sml_sources "")
+endif(SML_FOUND)
 
 add_executable(mock_metermap mock_metermap.cpp ../../src/Meter.cpp ../../src/Options.cpp
 	../../src/protocols/MeterD0.cpp
@@ -17,7 +22,7 @@ add_executable(mock_metermap mock_metermap.cpp ../../src/Meter.cpp ../../src/Opt
 	../../src/protocols/MeterExec.cpp
 	../../src/protocols/MeterS0.cpp
 	../../src/protocols/MeterRandom.cpp
-	../../src/protocols/MeterSML.cpp
+	${mock_sml_sources}
 	../../src/protocols/MeterFluksoV2.cpp
 	../../src/protocols/MeterW1therm.cpp
 	../../src/Reading.cpp
@@ -48,7 +53,7 @@ if (MICROHTTPD_FOUND)
     target_link_libraries(mock_metermap ${MICROHTTPD_LIBRARY})
 endif(MICROHTTPD_FOUND)
 
-target_link_libraries(mock_metermap ${GNUTLS_LIBRARIES} ${OPENSSL_LIBRARIES})
+target_link_libraries(mock_metermap unistring ${GNUTLS_LIBRARIES} ${OPENSSL_LIBRARIES})
 
 target_link_libraries(mock_metermap 
 		${GTEST_LIBS_DIR}/libgtest.a

--- a/tests/ut_meter.cpp
+++ b/tests/ut_meter.cpp
@@ -37,7 +37,9 @@ TEST(meter, meter_lookup_protocol)
 
 	ASSERT_EQ(SUCCESS, meter_lookup_protocol("random", NULL));
 	ASSERT_EQ(SUCCESS, meter_lookup_protocol("s0", NULL));
+#ifdef SML_SUPPORT 
 	ASSERT_EQ(SUCCESS, meter_lookup_protocol("sml", NULL));
+#endif
 	ASSERT_EQ(SUCCESS, meter_lookup_protocol("fluksov2", NULL));
 
 	ASSERT_EQ(ERR_NOT_FOUND, meter_lookup_protocol("d01", NULL));


### PR DESCRIPTION
gnutls on ubuntu18.04 seems to need libunistring-dev. This seems to be due to some changes in Ubuntu (use the provided libunistring instead of previously shipped one from gnutls) but the pkgconfig files seem to miss that yet. 
For now add the linking to libunistring manually. But we should monitor and remove this once fixed in Ubuntu.
Some minor cleanups to enable compile and test without SML support as well.