### PR TITLE
Implement _use_local_time option in OMS meter

### DIFF
--- a/etc/vzlogger_generic.schema.json
+++ b/etc/vzlogger_generic.schema.json
@@ -720,6 +720,11 @@
                             "type": "boolean",
                             "default": false,
                             "description": "provide some more debug output on console by calling some libmbus debug functions"
+                        },
+                        "use_local_time": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "use the local time for reading timestamp?"
                         }
                     },
                     "required": ["protocol", "device", "key"]

--- a/include/protocols/MeterOMS.hpp
+++ b/include/protocols/MeterOMS.hpp
@@ -65,6 +65,7 @@ protected:
 	unsigned char *_aes_key;
 	std::string _device;
 	bool _mbus_debug;
+	bool _use_local_time;
 	double _last_timestamp;
 };
 

--- a/src/protocols/MeterOMS.cpp
+++ b/src/protocols/MeterOMS.cpp
@@ -134,6 +134,7 @@ MeterOMS::MeterOMS(const std::list<Option> &options, OMSHWif *hwif) :
   , _hwif (hwif)
   , _aes_key(0)
   , _mbus_debug(false)
+  , _use_local_time(false)
   , _last_timestamp(0.0)
 {
 	OptionList optlist;
@@ -178,6 +179,12 @@ MeterOMS::MeterOMS(const std::list<Option> &options, OMSHWif *hwif) :
 	try {
 		_mbus_debug = optlist.lookup_bool(options, "mbus_debug");
 	} catch (vz::VZException &e) {
+		// keep default
+	}
+
+	try {
+		_use_local_time = optlist.lookup_bool(options, "use_local_time");
+	} catch (vz::OptionNotFoundException &e) {
 		// keep default
 	}
 
@@ -349,7 +356,7 @@ ssize_t MeterOMS::read(std::vector<Reading> &rds, size_t n)
 											if (ret<n) {
 												rds[ret].identifier(new ObisIdentifier("1.8.0"));
 												rds[ret].value(get_record_value(record));
-												if (timeFromMeter>1.0)
+												if (timeFromMeter>1.0 && !_use_local_time)
 													rds[ret].time_from_double(timeFromMeter);
 												else
 													rds[ret].time();
@@ -365,7 +372,7 @@ ssize_t MeterOMS::read(std::vector<Reading> &rds, size_t n)
 											if (ret < n) {
 												rds[ret].identifier(new ObisIdentifier("2.8.0"));
 												rds[ret].value(get_record_value(record));
-												if (timeFromMeter>1.0)
+												if (timeFromMeter>1.0 && !_use_local_time)
 													rds[ret].time_from_double(timeFromMeter);
 												else
 													rds[ret].time();
@@ -381,7 +388,7 @@ ssize_t MeterOMS::read(std::vector<Reading> &rds, size_t n)
 											if (ret < n) {
 												rds[ret].identifier(new ObisIdentifier("1.7.0"));
 												rds[ret].value(get_record_value(record));
-												if (timeFromMeter>1.0)
+												if (timeFromMeter>1.0 && !_use_local_time)
 													rds[ret].time_from_double(timeFromMeter);
 												else
 													rds[ret].time();
@@ -397,7 +404,7 @@ ssize_t MeterOMS::read(std::vector<Reading> &rds, size_t n)
 											if (ret < n) {
 												rds[ret].identifier(new ObisIdentifier("2.7.0"));
 												rds[ret].value(get_record_value(record));
-												if (timeFromMeter>1.0)
+												if (timeFromMeter>1.0 && !_use_local_time)
 													rds[ret].time_from_double(timeFromMeter);
 												else
 													rds[ret].time();


### PR DESCRIPTION
Related to #364 

Enables the use_local_time option to work with OMS meters as well.