### PR TITLE
Added automatic reopen of underlying device in case of libsml read 0.

### DIFF
--- a/gmock/CMakeLists.txt
+++ b/gmock/CMakeLists.txt
@@ -19,6 +19,6 @@ set(GTEST_INCLUDE_DIRS ${source_dir}/googletest/include PARENT_SCOPE)
 
 # Specify MainTest's link libraries
 ExternalProject_Get_Property(googlemock binary_dir)
-set(GTEST_LIBS_DIR ${binary_dir}/googlemock/gtest PARENT_SCOPE)
-set(GMOCK_LIBS_DIR ${binary_dir}/googlemock PARENT_SCOPE)
+set(GTEST_LIBS_DIR ${binary_dir}/lib PARENT_SCOPE)
+set(GMOCK_LIBS_DIR ${binary_dir}/lib PARENT_SCOPE)
 

--- a/include/protocols/MeterSML.hpp
+++ b/include/protocols/MeterSML.hpp
@@ -8,7 +8,7 @@
  * @author Steffen Vogel <info@steffenvogel.de>
  * @author Juri Glass
  * @author Mathias Runge
- * @author Nadim El Sayed 
+ * @author Nadim El Sayed
  */
 /*
  * This file is part of volkzaehler.org
@@ -26,7 +26,7 @@
  * You should have received a copy of the GNU General Public License
  * along with volkszaehler.org. If not, see <http://www.gnu.org/licenses/>.
  */
- 
+
 #ifndef _SML_H_
 #define _SML_H_
 
@@ -54,7 +54,7 @@ public:
 
 	const char *host() const { return _host.c_str(); }
 	const char *device() const { return _device.c_str(); }
-  
+
 protected:
 	std::string _host;
 	std::string _device;
@@ -62,11 +62,17 @@ protected:
 	parity_type_t _parity;
 	std::string _pull;
 	bool _use_local_time;
-	
+
 	int _fd;	/* file descriptor of port */
 	struct termios _old_tio;	/* required to reset port */
 
 	const int BUFFER_LEN;
+
+	/**
+	 * @brief reopen the underlying device. We do this to workaround issue #362
+	 * @return true if reopen was successful. False otherwise.
+	 * */
+	bool reopen();
 
 	/**
 	 * Parses SML list entry and stores it in reading pointed by rd

--- a/src/protocols/MeterSML.cpp
+++ b/src/protocols/MeterSML.cpp
@@ -222,6 +222,14 @@ ssize_t MeterSML::read(std::vector<Reading> &rds, size_t n) {
 	sml_get_list_response *body;
 	sml_list *entry;
 
+	if (_fd < 0) {
+		if (!reopen()) {
+			// sleep a little bit to prevent busy looping
+			sleep(1);
+			return 0;
+		}
+	}
+
 	if (_pull.size()) {
 		int wlen = write(_fd,_pull.c_str(),_pull.size());
 		print(log_debug,"sending pullsequenz send (len:%d is:%d).", name().c_str(), _pull.size(), wlen);


### PR DESCRIPTION
As a workaround for #362 added an automatic reopen if
sml_transport_read returns 0 bytes.
Added a few minor issues like uninitialized variables (_fd), missing free in error case as well.
Issue: #362

Untested (as I have no good SML device nor mock).