### PR TITLE
Feature/mqtt timestamps

### DIFF
--- a/etc/vzlogger.conf
+++ b/etc/vzlogger.conf
@@ -51,6 +51,8 @@
         "pass": "", // optional password for the mqtt server
         "retain": false, // optional use retain message flag
         "rawAndAgg": false, // optional publish raw values even if agg mode is used
+        "qos": 0, // optional quality of service, default is 0
+        "timestamp": false // optional whether to include a timestamp in the payload
     },
 
 

--- a/include/mqtt.hpp
+++ b/include/mqtt.hpp
@@ -45,6 +45,8 @@ class MqttClient
 	bool _retain = false;
 	bool _rawAndAgg = false;
 	std::string _topic;
+	int _qos = 0;
+	bool _timestamp = false;
 
 	bool _isConnected  = false;
 


### PR DESCRIPTION
Add options for MQTT publishing:

- New option "qos" for MQTT: Allow to configure the MQTT QoS value (was fixed to zero)
- New option "timestamp" for MQTT: Allow to include a the reading timestamp value in the payload of the message. MQTT message do not have a timestamp and in situations where the values are buffered in a queue (qos > 0) this information is necessary. 