### PR TITLE
Specify dependencies for tests to support parallel building

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -37,6 +37,8 @@ endif( OMS_SUPPORT )
 
 add_executable(vzlogger_unit_tests ${test_sources} ../src/CurlSessionProvider.cpp ../src/protocols/MeterW1therm.cpp ${oms_sources} ${MQTT_SOURCES})
 
+add_dependencies(vzlogger_unit_tests googletest googlemock)
+
 target_link_libraries(vzlogger_unit_tests
     ${GTEST_LIBS_DIR}/libgtest.a
     ${GMOCK_LIBS_DIR}/libgmock.a

--- a/tests/mocks/CMakeLists.txt
+++ b/tests/mocks/CMakeLists.txt
@@ -55,6 +55,8 @@ add_executable(mock_metermap mock_metermap.cpp ../../src/Meter.cpp ../../src/Opt
 	${mock_mqtt_sources}
 )
 
+add_dependencies(mock_metermap googletest googlemock)
+
 target_link_libraries(mock_metermap ${CURL_STATIC_LIBRARIES} ${CURL_LIBRARIES})
 
 if (MICROHTTPD_FOUND)
@@ -90,6 +92,8 @@ add_executable(mock_MeterW1therm
     ../../src/Options.cpp
 )
 
+add_dependencies(mock_MeterW1therm googletest googlemock)
+
 target_link_libraries(mock_MeterW1therm
 		${GTEST_LIBS_DIR}/libgtest.a
 		${GMOCK_LIBS_DIR}/libgmock.a
@@ -110,6 +114,9 @@ add_executable(mock_MeterOMS
 	../../src/Obis.cpp
 	../../src/Options.cpp
 )
+
+add_dependencies(mock_MeterOMS googletest googlemock)
+
 target_link_libraries(mock_MeterOMS
 		${GTEST_LIBS_DIR}/libgtest.a
 		${GMOCK_LIBS_DIR}/libgmock.a
@@ -131,6 +138,8 @@ add_executable(mock_MeterS0
 	../../src/Obis.cpp
 	../../src/Options.cpp
 )
+
+add_dependencies(mock_MeterS0 googletest googlemock)
 
 target_link_libraries(mock_MeterS0
 		${GTEST_LIBS_DIR}/libgtest.a


### PR DESCRIPTION
Currently when trying to build in parallel (e.g. by using cmake . --build -j or building the debian package with a recent debhelper version), the build will fail, if gtest/gmock hasn't been built before:

The error looks something like this:

`In file included from /home/andreas/devel/github/vzlogger/include/Meter.hpp:33,
                 from /home/andreas/devel/github/vzlogger/src/Meter.cpp:29:
/home/andreas/devel/github/vzlogger/tests/mocks/./Channel.hpp:4:10: fatal error: gmock/gmock.h: No such file or directory
 #include <gmock/gmock.h>
          ^~~~~~~~~~~~~~~
cc1plus: all warnings being treated as errors
compilation terminated.
make[2]: *** [tests/mocks/CMakeFiles/mock_metermap.dir/build.make:79: tests/mocks/CMakeFiles/mock_metermap.dir/__/__/src/Meter.cpp.o] Error 1
make[2]: Leaving directory '/home/andreas/devel/github/vzlogger'
make[1]: *** [CMakeFiles/Makefile2:1386: tests/mocks/CMakeFiles/mock_metermap.dir/all] Error 2
`
By adding depency information to the test targets, cmake knows to build gtest/gmock first and the tests after.