### PR TITLE
If a curl session is still in use retry up to five times.

### DIFF
--- a/src/CurlSessionProvider.cpp
+++ b/src/CurlSessionProvider.cpp
@@ -9,6 +9,7 @@
 
 #include <assert.h>
 #include <time.h>
+#include <unistd.h>
 #include "CurlSessionProvider.hpp"
 
 CurlSessionProvider::CurlSessionProvider()
@@ -20,19 +21,37 @@ CurlSessionProvider::CurlSessionProvider()
 CurlSessionProvider::~CurlSessionProvider()
 {
     // curl_easy_cleanup for each CURL*
-    timespec ts;
-    clock_gettime(CLOCK_REALTIME , &ts);
-    ts.tv_sec+=1;
-    pthread_mutex_timedlock(&_map_mutex, &ts); // try max 1s to acquire the lock. There might have been another thread pthread_cancelled while owning the lock.
-    for (map_it it = _easy_handle_map.begin(); it!=_easy_handle_map.end(); ++it)
-    {
-        CurlUsage cu = (*it).second;
-        curl_easy_cleanup(cu.eh);
-    }
-    curl_global_cleanup();
-
-    pthread_mutex_unlock(&_map_mutex);
-    pthread_mutex_destroy(&_map_mutex);
+	unsigned inUseRetry = 5;
+	do{
+		timespec ts;
+		clock_gettime(CLOCK_REALTIME , &ts);
+		ts.tv_sec+=1;
+		pthread_mutex_timedlock(&_map_mutex, &ts); // try max 1s to acquire the lock. There might have been another thread pthread_cancelled while owning the lock.
+		// check whether any is still inUse:
+		bool inUse = false;
+		for (map_it it = _easy_handle_map.begin(); it != _easy_handle_map.end(); ++it)
+		{
+			CurlUsage cu = (*it).second;
+			if (cu.inUse){
+				inUse = true;
+			}
+		}
+		if (!inUse or inUseRetry==1) {
+			inUseRetry = 0;
+			for (map_it it = _easy_handle_map.begin(); it != _easy_handle_map.end(); ++it)
+			{
+				CurlUsage cu = (*it).second;
+				curl_easy_cleanup(cu.eh);
+			}
+			curl_global_cleanup();
+		}
+		pthread_mutex_unlock(&_map_mutex);
+		if (inUseRetry>0) {
+			sleep(1); // have to do this without holding mutex
+			inUseRetry--;
+		}
+	} while (inUseRetry > 0);
+	pthread_mutex_destroy(&_map_mutex);
 }
 
 // thread-safe functions:


### PR DESCRIPTION
To fix #386 we wait up to 5 times with 1sec in between (so max 4s)
at shutdown before we cancel the pending curl sessions.
Issue: #386