### PR TITLE
Make build compatible to Raspbian

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -294,6 +294,11 @@ INSTALL(FILES README.md COPYING DESTINATION
   share/doc/vzlogger-${VZLOGGER_MAJOR_VERSION}-${VZLOGGER_MINOR_VERSION}
 )
 
+INSTALL(FILES etc/vzlogger.conf DESTINATION /etc)
+INSTALL(FILES etc/vzlogger.conf.InfluxDB etc/vzlogger.conf.meterOCR etc/vzlogger.conf.meterOMS etc/vzlogger.conf.mySmartGrid DESTINATION
+  share/doc/vzlogger-${VZLOGGER_MAJOR_VERSION}-${VZLOGGER_MINOR_VERSION}
+)
+
 # add clean-all target that removes the cached files from cmake as well (see e.g. issue #186)
 add_custom_target(clean-all
     COMMAND ${CMAKE_BUILD_TOOL} clean

--- a/debian/vzlogger.init
+++ b/debian/vzlogger.init
@@ -16,7 +16,6 @@ DESC="smartmetering server"
 NAME=vzlogger
 DAEMON=/usr/bin/vzlogger
 DAEMON_ARGS="-d"          # Arguments to run the daemon with
-#PIDFILE=/var/run/$NAME.pid
 SCRIPTNAME=/etc/init.d/$NAME
 USER=vzlogger
 GROUP=vzlogger

--- a/debian/vzlogger.postinst
+++ b/debian/vzlogger.postinst
@@ -3,13 +3,15 @@
 case "$1" in
     configure)
 	if ! id vzlogger > /dev/null 2>&1 ; then
-	    adduser --system --no-create-home \
+	    adduser --system --home /var/lib/vzlogger \
 		--group --disabled-password --shell /bin/false \
 		vzlogger
             usermod -a -G dialout vzlogger
 	fi
 
+	mkdir /var/lib/vzlogger || true
 	touch /var/log/vzlogger.log
+	chown vzlogger:adm /var/lib/vzlogger
 	chown vzlogger:adm /var/log/vzlogger.log
     ;;
 


### PR DESCRIPTION
- Place binary in /usr/bin instead of /usr/local/bin
- Add some of the example configuration files to the doc directory
- Create home directory for the vzlogger user

Maybe, it's helpful.
Works on Raspbian stretch and buster.