### PR TITLE
Added Reading::operator= to avoid implicit declaration.

### DIFF
--- a/include/Reading.hpp
+++ b/include/Reading.hpp
@@ -143,6 +143,7 @@ public:
 	Reading(ReadingIdentifier::Ptr pIndentifier);
 	Reading(double pValue, struct timeval pTime, ReadingIdentifier::Ptr pIndentifier);
 	Reading(const Reading &orig);
+	Reading &operator=(const Reading &orig);
 
 	bool deleted() const { return _deleted; }
 	void  mark_delete()        { _deleted = true; }

--- a/src/Reading.cpp
+++ b/src/Reading.cpp
@@ -71,6 +71,15 @@ Reading::Reading(
 {
 }
 
+Reading &Reading::operator=(const Reading &orig)
+{
+	_deleted = orig._deleted;
+	_value = orig._value;
+	_time = orig._time;
+	_identifier = orig._identifier;
+	return *this;
+}
+
 void Reading::time_from_double(double const &ts)
 {
 	double integral;


### PR DESCRIPTION
Even though the implicit one works let's silence some warnings.
I need to think about defining them explicitly but with default
implementation (but am not really sure yet).

Issue: #394