### PR TITLE
Fixed g++-8 compiler error

### DIFF
--- a/include/Reading.hpp
+++ b/include/Reading.hpp
@@ -45,7 +45,7 @@ class ReadingIdentifier {
 	virtual ~ReadingIdentifier(){};
 
 	virtual size_t unparse(char *buffer, size_t n) = 0;
-	virtual bool operator==(ReadingIdentifier const &cmp) const;
+  bool operator==(ReadingIdentifier const &cmp) const;
 	bool compare(ReadingIdentifier const *lhs, ReadingIdentifier const *rhs) const;
 
 	virtual const std::string toString() = 0;


### PR DESCRIPTION
operator== should not be virtual, since it is not re-implemented in derived classes. Instead, new operators are created with different argument types, which shadow the operator== of the base class. 