### PR TITLE
Gtest cmake fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -79,7 +79,11 @@ install:
     fi
 
 script:
-  - if [ -n "$BUILD" ]; then cmake . -DMETEREXEC_ROOTACCESS=OFF -DENABLE_OCR=ON -DSML_HOME=/usr/local/src/libsml/sml && make && make test; fi
+  - ls
+  - |if [ -n "$BUILD" ]; then
+       mkdir -p build
+       cd build
+       cmake ../vzlogger -DMETEREXEC_ROOTACCESS=OFF -DENABLE_OCR=ON -DSML_HOME=/usr/local/src/libsml/sml && make && make test; fi
   - |
     if [ -n "$FORMAT" ]; then
       clang-format -i include/**/*.{h,hpp} src/**/*.cpp tests/**/*.{cpp,hpp}

--- a/.travis.yml
+++ b/.travis.yml
@@ -80,10 +80,12 @@ install:
 
 script:
   - ls
-  - |if [ -n "$BUILD" ]; then
-       mkdir -p build
-       cd build
-       cmake ../vzlogger -DMETEREXEC_ROOTACCESS=OFF -DENABLE_OCR=ON -DSML_HOME=/usr/local/src/libsml/sml && make && make test; fi
+  - |
+    if [ -n "$BUILD" ]; then
+      mkdir -p build
+      cd build
+      cmake ../vzlogger -DMETEREXEC_ROOTACCESS=OFF -DENABLE_OCR=ON -DSML_HOME=/usr/local/src/libsml/sml && make && make test
+    fi
   - |
     if [ -n "$FORMAT" ]; then
       clang-format -i include/**/*.{h,hpp} src/**/*.cpp tests/**/*.{cpp,hpp}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -209,7 +209,41 @@ include(CTest)
 enable_testing()
 
 if(GIT_FOUND AND ENABLE_GOOGLEMOCK)
-  add_subdirectory(gmock)
+  #add_subdirectory(gmock)
+
+  # Download and unpack googletest at configure time
+  configure_file(gtest/CMakeLists.txt.in gtest-download/CMakeLists.txt)
+  execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
+  RESULT_VARIABLE result
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/gtest-download )
+  if(result)
+      message(FATAL_ERROR "CMake step for googletest failed: ${result}")
+  endif()
+  execute_process(COMMAND ${CMAKE_COMMAND} --build .
+  RESULT_VARIABLE result
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/gtest-download )
+  if(result)
+      message(FATAL_ERROR "Build step for googletest failed: ${result}")
+  endif()
+
+  # Prevent overriding the parent project's compiler/linker
+  # settings on Windows
+  set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+
+  # Add googletest directly to our build. This defines
+  # the gtest and gtest_main targets.
+  add_subdirectory(${CMAKE_CURRENT_BINARY_DIR}/gtest-src
+                   ${CMAKE_CURRENT_BINARY_DIR}/gtest-build
+                   EXCLUDE_FROM_ALL)
+
+  # The gtest/gtest_main targets carry header search path
+  # dependencies automatically when using CMake 2.8.11 or
+  # later. Otherwise we have to add them here ourselves.
+  if (CMAKE_VERSION VERSION_LESS 2.8.11)
+      include_directories("${gtest_SOURCE_DIR}/include")
+      include_directories("${gmock_SOURCE_DIR}/include")
+  endif()
+
   add_subdirectory(tests)
 else()
  if (ENABLE_GOOGLEMOCK)

--- a/gtest/CMakeLists.txt.in
+++ b/gtest/CMakeLists.txt.in
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 2.8.2)
+
+project(gtest-download NONE)
+
+include(ExternalProject)
+ExternalProject_Add(googletest
+  GIT_REPOSITORY    https://github.com/google/googletest.git
+  GIT_TAG           master
+  SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/gtest-src"
+  BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/gtest-build"
+  CONFIGURE_COMMAND ""
+  BUILD_COMMAND     ""
+  INSTALL_COMMAND   ""
+  TEST_COMMAND      ""
+)

--- a/include/Reading.hpp
+++ b/include/Reading.hpp
@@ -45,7 +45,7 @@ class ReadingIdentifier {
 	virtual ~ReadingIdentifier(){};
 
 	virtual size_t unparse(char *buffer, size_t n) = 0;
-	virtual bool operator==(ReadingIdentifier const &cmp) const;
+  bool operator==(ReadingIdentifier const &cmp) const;
 	bool compare(ReadingIdentifier const *lhs, ReadingIdentifier const *rhs) const;
 
 	virtual const std::string toString() = 0;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,7 +1,7 @@
-include_directories(
-    ${GMOCK_INCLUDE_DIRS}
-    ${GTEST_INCLUDE_DIRS}
-)
+#include_directories(
+#    ${GMOCK_INCLUDE_DIRS}
+#    ${GTEST_INCLUDE_DIRS}
+#)
 
 # all *.cpp files here will be used.
 file(GLOB test_sources *.cpp)
@@ -36,12 +36,9 @@ elseif( OMS_SUPPORT )
 endif( OMS_SUPPORT )
 
 add_executable(vzlogger_unit_tests ${test_sources} ../src/CurlSessionProvider.cpp ../src/protocols/MeterW1therm.cpp ${oms_sources} ${MQTT_SOURCES})
-
-add_dependencies(vzlogger_unit_tests googlemock)
-
 target_link_libraries(vzlogger_unit_tests
-    ${GTEST_LIBS_DIR}/libgtest.a
-    ${GMOCK_LIBS_DIR}/libgmock.a
+    gtest
+    gmock
     ${JSON_LIBRARY}
     ${LIBUUID}
     dl

--- a/tests/mocks/CMakeLists.txt
+++ b/tests/mocks/CMakeLists.txt
@@ -55,8 +55,6 @@ add_executable(mock_metermap mock_metermap.cpp ../../src/Meter.cpp ../../src/Opt
 	${mock_mqtt_sources}
 )
 
-add_dependencies(mock_metermap googlemock)
-
 target_link_libraries(mock_metermap ${CURL_STATIC_LIBRARIES} ${CURL_LIBRARIES})
 
 if (MICROHTTPD_FOUND)
@@ -64,10 +62,9 @@ if (MICROHTTPD_FOUND)
 endif(MICROHTTPD_FOUND)
 
 target_link_libraries(mock_metermap unistring ${GNUTLS_LIBRARIES} ${OPENSSL_LIBRARIES})
-
 target_link_libraries(mock_metermap
-		${GTEST_LIBS_DIR}/libgtest.a
-		${GMOCK_LIBS_DIR}/libgmock.a
+        gtest
+        gmock
 		pthread
 		${JSON_LIBRARY}
 		${LIBUUID}
@@ -92,11 +89,9 @@ add_executable(mock_MeterW1therm
     ../../src/Options.cpp
 )
 
-add_dependencies(mock_MeterW1therm googlemock)
-
 target_link_libraries(mock_MeterW1therm
-		${GTEST_LIBS_DIR}/libgtest.a
-		${GMOCK_LIBS_DIR}/libgmock.a
+        gtest
+        gmock
 		pthread
 		${JSON_LIBRARY}
 		${LIBUUID}
@@ -115,11 +110,9 @@ add_executable(mock_MeterOMS
 	../../src/Options.cpp
 )
 
-add_dependencies(mock_MeterOMS googlemock)
-
 target_link_libraries(mock_MeterOMS
-		${GTEST_LIBS_DIR}/libgtest.a
-		${GMOCK_LIBS_DIR}/libgmock.a
+        gtest
+        gmock
 		pthread
 		${JSON_LIBRARY}
 		${LIBUUID}
@@ -139,11 +132,9 @@ add_executable(mock_MeterS0
 	../../src/Options.cpp
 )
 
-add_dependencies(mock_MeterS0 googlemock)
-
 target_link_libraries(mock_MeterS0
-		${GTEST_LIBS_DIR}/libgtest.a
-		${GMOCK_LIBS_DIR}/libgmock.a
+        gtest
+        gmock
 		pthread
 		${JSON_LIBRARY}
 		${LIBUUID}


### PR DESCRIPTION
With cmake 3.10.2 I cannot configure the project with googletest because CMAKE_CXX_COMPILER is not defined (only for the googletest subproject). Thus I adapted the cmake build script according to the recommendations in the [googletest README](https://github.com/google/googletest/blob/master/googletest/README.md). This works fine on my machine. 

I removed various `include_directories` statements and changed the dependency definition of some targets to the now recommended cmake way. This may break with cmake < 3.0, but I cannot test this. Not sure, whether bumping the min required version to 3.x would be a problem, though.