### PR TITLE
Fixed shadowing of operator== by classes derived from ReadingIdentifier

### DIFF
--- a/include/Reading.hpp
+++ b/include/Reading.hpp
@@ -45,7 +45,7 @@ class ReadingIdentifier {
 	virtual ~ReadingIdentifier(){};
 
 	virtual size_t unparse(char *buffer, size_t n) = 0;
-	virtual bool operator==(ReadingIdentifier const &cmp) const;
+	bool operator==(ReadingIdentifier const &cmp) const;
 	bool compare(ReadingIdentifier const *lhs, ReadingIdentifier const *rhs) const;
 
 	virtual const std::string toString() = 0;


### PR DESCRIPTION
Second try.