### PR TITLE
Added config option to specify MQTT protocol version

### DIFF
--- a/etc/vzlogger.conf
+++ b/etc/vzlogger.conf
@@ -52,9 +52,9 @@
         "retain": false, // optional use retain message flag
         "rawAndAgg": false, // optional publish raw values even if agg mode is used
         "qos": 0, // optional quality of service, default is 0
-        "timestamp": false // optional whether to include a timestamp in the payload
+        "timestamp": false, // optional whether to include a timestamp in the payload
+        "protocol": "3.1.1" // specify MQTT protocol version. Either 3.1 or 3.1.1
     },
-
 
     // Meter configuration
     "meters": [

--- a/etc/vzlogger.conf
+++ b/etc/vzlogger.conf
@@ -52,8 +52,7 @@
         "retain": false, // optional use retain message flag
         "rawAndAgg": false, // optional publish raw values even if agg mode is used
         "qos": 0, // optional quality of service, default is 0
-        "timestamp": false, // optional whether to include a timestamp in the payload
-        "protocol": "3.1.1" // specify MQTT protocol version. Either 3.1 or 3.1.1
+        "timestamp": false // optional whether to include a timestamp in the payload
     },
 
     // Meter configuration

--- a/include/mqtt.hpp
+++ b/include/mqtt.hpp
@@ -47,6 +47,7 @@ class MqttClient {
 	std::string _topic;
 	int _qos = 0;
 	bool _timestamp = false;
+	int _protocol;
 
 	bool _isConnected = false;
 

--- a/include/mqtt.hpp
+++ b/include/mqtt.hpp
@@ -47,7 +47,6 @@ class MqttClient {
 	std::string _topic;
 	int _qos = 0;
 	bool _timestamp = false;
-	int _protocol;
 
 	bool _isConnected = false;
 

--- a/src/mqtt.cpp
+++ b/src/mqtt.cpp
@@ -15,7 +15,7 @@ MqttClient *mqttClient = 0;
 volatile bool endMqttClientThread = false;
 
 // class impl.
-MqttClient::MqttClient(struct json_object *option) : _enabled(false), _protocol(MQTT_PROTOCOL_V31) {
+MqttClient::MqttClient(struct json_object *option) : _enabled(false) {
 	print(log_finest, "MqttClient::MqttClient called", "mqtt");
 	if (option) {
 		assert(json_object_get_type(option) == json_type_object);
@@ -60,16 +60,6 @@ MqttClient::MqttClient(struct json_object *option) : _enabled(false), _protocol(
 				}
 			} else if (strcmp(key, "timestamp") == 0 && local_type == json_type_boolean) {
 				_timestamp = json_object_get_boolean(local_value);
-			} else if (strcmp(key, "protocol") == 0 && local_type == json_type_string) {
-				std::string tmp = json_object_get_string(local_value);
-				if (tmp == "3.1") {
-					_protocol = MQTT_PROTOCOL_V31;
-				} else if (tmp == "3.1.1") {
-					_protocol = MQTT_PROTOCOL_V311;
-				} else {
-					print(log_alert, "Ignoring invalid MQTT protocol '%s'. Using default", NULL,
-						  tmp.c_str());
-				}
 			} else {
 				print(log_alert, "Ignoring invalid field or type: %s=%s", NULL, key,
 					  json_object_get_string(local_value));
@@ -148,7 +138,8 @@ MqttClient::MqttClient(struct json_object *option) : _enabled(false), _protocol(
 				}
 			}
 
-			res = mosquitto_opts_set(_mcs, MOSQ_OPT_PROTOCOL_VERSION, &_protocol);
+			int protocol = MQTT_PROTOCOL_V311;
+			res = mosquitto_opts_set(_mcs, MOSQ_OPT_PROTOCOL_VERSION, &protocol);
 			if (res != MOSQ_ERR_SUCCESS) {
 				print(log_warning, "unable to set MQTT protocol version (error %d)", "mqtt", res);
 			}


### PR DESCRIPTION
Several applications I tested require MQTT version 3.1.1. vzlogger seems to default to 3.1. So I propose to add a config option "protocol" to make the version configurable. I set the default to 3.1 to not break existing code.