### PR TITLE
Add lock/unlock before iterating buffer

### DIFF
--- a/src/threads.cpp
+++ b/src/threads.cpp
@@ -143,12 +143,17 @@ void *reading_thread(void *arg) {
 				if (mqttClient) {
 					Buffer::Ptr buf = (*ch)->buffer();
 					Buffer::iterator it;
+					buf->lock();
 					for (it = buf->begin(); it != buf->end(); ++it) {
-						Reading &r = *it;
-						if (!r.deleted()) {
-							mqttClient->publish((*ch), r, true);
+						if (&*it) { // this seems dirty. see issue #427
+									// the lock()/unlock() should avoid it.
+							Reading &r = *it;
+							if (!r.deleted()) {
+								mqttClient->publish((*ch), r, true);
+							}
 						}
 					}
+					buf->unlock();
 				}
 #endif
 


### PR DESCRIPTION
As *it was 0 (see #427) it seems either an
nulptr was casted wrongly or
the buffer was modified in between the iterations.
Avoid this with the lock/unlock and additional check.
Issue: #427