### PR TITLE
wrong keyword in configs

### DIFF
--- a/etc/vzlogger.conf
+++ b/etc/vzlogger.conf
@@ -62,7 +62,7 @@
             // Example SML meter
 
             "enabled": false,               // disabled meters will be ignored (default)
-            "skip": false,                  // errors when opening meter may be ignored if enabled
+            "allowskip": false,                  // errors when opening meter may be ignored if enabled
             "protocol": "sml",              // meter protocol, see 'vzlogger -h' for full list
             "device": "/dev/ttyUSB1",       // meter device
 //          "host": "http://my.ddns.net::7331",   // uri if meter not locally connected using <device>
@@ -93,7 +93,7 @@
             // Example S0 meter
 
             "enabled": false,               // disabled meters will be ignored (default)
-            "skip": false,                  // errors when opening meter may be ignored if enabled
+            "allowskip": false,                  // errors when opening meter may be ignored if enabled
             "protocol": "s0",               // meter protocol, see 'vzlogger -h' for full list
             "device": "/dev/ttyUSB0",       // meter device
 
@@ -114,7 +114,7 @@
             // Example D0 meter
 
             "enabled": false,               // disabled meters will be ignored (default)
-            "skip": false,                  // errors when opening meter may be ignored if enabled
+            "allowskip": false,                  // errors when opening meter may be ignored if enabled
             "protocol": "d0",               // meter protocol, see 'vzlogger -h' for full list
             "device": "/dev/ttyUSB0",       // meter device
             "dump_file": "/var/log/d0.txt", // detailed log file for all received/transmitted data (optional)
@@ -143,7 +143,7 @@
         // examples for non-device protocols
         {
             "enabled": false,               // disabled meters will be ignored
-            "skip": false,                  // errors when opening meter may be ignored if enabled
+            "allowskip": false,                  // errors when opening meter may be ignored if enabled
 
             "protocol": "random",
             "interval": 2,
@@ -156,7 +156,7 @@
         },
         {
             "enabled": false,               // disabled meters will be ignored
-            "skip": false,                  // errors when opening meter may be ignored if enabled
+            "allowskip": false,                  // errors when opening meter may be ignored if enabled
 
             "protocol": "file",
             "path": "/proc/loadavg",
@@ -169,7 +169,7 @@
         },
         {
             "enabled": false,               // disabled meters will be ignored
-            "skip": false,                  // if enabled, errors when opening meter will lead to meter being ignored
+            "allowskip": false,                  // if enabled, errors when opening meter will lead to meter being ignored
             "protocol": "exec",
             "command": "python /path/to/yourscript.py", // is the command line as you'll type it in the shell - remember to test your command from the root directory
             //          "format": "$i $v $t",           // a format string for parsing complex logfiles
@@ -182,7 +182,7 @@
         // examples for Flukso-based sensors
         {
             "enabled": false,               // disabled meters will be ignored
-            "skip": false,                  // errors when opening meter may be ignored if enabled
+            "allowskip": false,                  // errors when opening meter may be ignored if enabled
 
             "protocol": "fluksov2",
             "fifo": "/var/spid/delta/out",
@@ -196,7 +196,7 @@
         // example for 1wire temp sensors
         {
             "enabled": false,
-            "skip": true,
+            "allowskip": true,
             "protocol": "w1therm"
         }
     ]

--- a/etc/vzlogger.conf.meterOCR
+++ b/etc/vzlogger.conf.meterOCR
@@ -14,7 +14,7 @@
 		// example for OCR (image processing/recognizing) "meter"
 		{
 			"enabled" : false,
-			"skip": true,
+			"allowskip": true,
 			"protocol": "ocr",
 			"impulses": 10000, // (optional, default 0 = no impules but abs. values), >0 impulses per unit
 //			"file": "/tmp/image.png", // name of file to be processed

--- a/etc/vzlogger.conf.meterOMS
+++ b/etc/vzlogger.conf.meterOMS
@@ -14,7 +14,7 @@
         // example for OMS (M-Bus based) meter
 		{
 			"enabled" : true,
-			"skip": false,
+			"allowskip": false,
 			"protocol": "oms",
 			"device": "/dev/ttyUSB0",
 			"baudrate": 9600, // optional default 9600

--- a/etc/vzlogger.conf.mySmartGrid
+++ b/etc/vzlogger.conf.mySmartGrid
@@ -14,7 +14,7 @@
         // examples for MySmartGrid as middleware
         {
             "enabled": false,               // disabled meters will be ignored
-            "skip": false,                  // if enabled, errors when opening meter will lead to meter being ignored
+            "allowskip": false,                  // if enabled, errors when opening meter will lead to meter being ignored
             "protocol": "d0",               // see 'vzlogger -h' for list of available protocols
             "device": "/dev/ttyUSB2",
             "interval": 2,
@@ -32,7 +32,7 @@
         },
         {
             "enabled": false,               // disabled meters will be ignored
-            "skip": false,                  // if enabled, errors when opening meter will lead to meter being ignored
+            "allowskip": false,                  // if enabled, errors when opening meter will lead to meter being ignored
             "protocol": "sml",              // see 'vzlogger -h' for list of available protocols
             "device": "/dev/ttyUSB0",
             "interval": 2,
@@ -50,7 +50,7 @@
         },
         {
             "enabled": false,               // disabled meters will be ignored
-            "skip": false,                  // if enabled, errors when opening meter will lead to meter being ignored
+            "allowskip": false,                  // if enabled, errors when opening meter will lead to meter being ignored
             "protocol": "s0",               // see 'vzlogger -h' for list of available protocols
             "device": "/dev/ttyUSB1",
             "interval": 2,


### PR DESCRIPTION
The keyword "skip" in example configurations is wrong. Should be "allowskip".