### PR TITLE
SSL Connect Error Volkszähler API

### DIFF
--- a/src/api/Volkszaehler.cpp
+++ b/src/api/Volkszaehler.cpp
@@ -295,6 +295,7 @@ int vz::api::curl_custom_debug_callback(CURL *curl, curl_infotype type, char *da
 										void *arg) {
 	Channel *ch = static_cast<Channel *>(arg);
 	char *end = strchr(data, '\n');
+	std::string buffer(data, size);
 
 	if (data == end)
 		return 0; // skip empty line
@@ -304,22 +305,19 @@ int vz::api::curl_custom_debug_callback(CURL *curl, curl_infotype type, char *da
 	case CURLINFO_END:
 		if (end)
 			*end = '\0'; // terminate without \n
-		print((log_level_t)(log_debug + 5), "CURL: %.*s", ch->name(), (int)size, data);
+		print((log_level_t)(log_debug + 5), "CURL: %.*s", ch->name(), (int)size, buffer.c_str());
 		break;
 
 	case CURLINFO_SSL_DATA_IN:
 	case CURLINFO_DATA_IN:
-		print((log_level_t)(log_debug + 5), "CURL: Received %lu bytes", ch->name(),
-			  (unsigned long)size);
-		print((log_level_t)(log_debug + 5), "CURL: Received '%s' bytes", ch->name(), data);
+		print((log_level_t)(log_debug + 5), "CURL: Received %lu bytes: '%s'", ch->name(),
+			  (unsigned long)size, buffer.c_str());
 		break;
 
 	case CURLINFO_SSL_DATA_OUT:
 	case CURLINFO_DATA_OUT:
-		std::string buffer(data, size);
-		print((log_level_t)(log_debug + 5), "CURL: Sent %lu bytes.. ", ch->name(),
-			  (unsigned long)size);
-		print((log_level_t)(log_debug + 5), "CURL: Sent '%s' bytes", ch->name(), buffer.c_str());
+		print((log_level_t)(log_debug + 5), "CURL: Sent %lu bytes: '%s'", ch->name(),
+			  (unsigned long)size, buffer.c_str());
 		break;
 
 	case CURLINFO_HEADER_IN:

--- a/src/api/Volkszaehler.cpp
+++ b/src/api/Volkszaehler.cpp
@@ -316,10 +316,10 @@ int vz::api::curl_custom_debug_callback(CURL *curl, curl_infotype type, char *da
 
 	case CURLINFO_SSL_DATA_OUT:
 	case CURLINFO_DATA_OUT:
-		//data[size] = 0;
+		std::string buffer(data, size);
 		print((log_level_t)(log_debug + 5), "CURL: Sent %lu bytes.. ", ch->name(),
 			  (unsigned long)size);
-		print((log_level_t)(log_debug + 5), "CURL: Sent '%s' bytes", ch->name(), data);
+		print((log_level_t)(log_debug + 5), "CURL: Sent '%s' bytes", ch->name(), buffer.c_str());
 		break;
 
 	case CURLINFO_HEADER_IN:

--- a/src/api/Volkszaehler.cpp
+++ b/src/api/Volkszaehler.cpp
@@ -316,7 +316,7 @@ int vz::api::curl_custom_debug_callback(CURL *curl, curl_infotype type, char *da
 
 	case CURLINFO_SSL_DATA_OUT:
 	case CURLINFO_DATA_OUT:
-		data[size] = 0;
+		//data[size] = 0;
 		print((log_level_t)(log_debug + 5), "CURL: Sent %lu bytes.. ", ch->name(),
 			  (unsigned long)size);
 		print((log_level_t)(log_debug + 5), "CURL: Sent '%s' bytes", ch->name(), data);


### PR DESCRIPTION
closes #430 
Das Pushen auf die Volkszähler API Middleware.php mit HTTPS hat nicht funktioniert. Das Auskommentieren einer Zeile behebt das Problem.

```
[Feb 05 11:07:22][chn0] CURL: Hostname example.com was found in DNS cache
[Feb 05 11:07:22][chn0] CURL:   Trying xx.xx.x.xx...
[Feb 05 11:07:22][chn0] CURL: TCP_NODELAY set
[Feb 05 11:07:22][chn0] CURL: Connected to example.com (xx.xx.xx.xx) port 443 (#48)
[Feb 05 11:07:22][chn0] CURL: ALPN, offering http/1.1
[Feb 05 11:07:22][chn0] CURL: successfully set certificate verify locations:
[Feb 05 11:07:22][chn0] CURL:   CAfile: /etc/ssl/certs/ca-certificates.crt
[Feb 05 11:07:22][chn0] CURL: Sent 5 bytes.. 
[Feb 05 11:07:22][chn0] CURL: Sent '����' bytes
[Feb 05 11:07:22][chn0] CURL: TLSv1.3 (OUT), TLS handshake, Client hello (1):
[Feb 05 11:07:22][chn0] CURL: Sent 512 bytes.. 
[Feb 05 11:07:22][chn0] CURL: Sent '�' bytes
[Feb 05 11:07:22][chn0] CURL: Received 5 bytes
[Feb 05 11:07:22][chn0] CURL: Received '���' bytes
[Feb 05 11:07:22][chn0] CURL: TLSv1.3 (IN), TLS alert, Server hello (2):
[Feb 05 11:07:22][chn0] CURL: Received 2 bytes
[Feb 05 11:07:22][chn0] CURL: Received '�
' bytes
[Feb 05 11:07:22][chn0] CURL: error:140943F2:SSL routines:ssl3_read_bytes:sslv3 alert unexpected message
[Feb 05 11:07:22][chn0] CURL: stopped the pause stream!
[Feb 05 11:07:22][chn0] CURL: Closing connection 48
[Feb 05 11:07:22][chn0] CURL: SSL connect error
[Feb 05 11:07:23][mtr0] Got 1 new readings from meter:
[Feb 05 11:07:23][mtr0] Reading: id=NilIdentifier/NilIdentifier value=20.62 ts=1612519643671
[Feb 05 11:07:23][chn0] Adding reading to queue (value=20.62 ts=1612519643671)
```