### PR TITLE
added Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+FROM debian:stable
+
+LABEL Description="vzlogger"
+
+# Dependencies 
+# https://wiki.volkszaehler.org/software/controller/vzlogger/installation_cpp-version
+RUN apt-get update && apt-get -y upgrade 
+RUN apt-get -y install build-essential git-core cmake pkg-config \
+    subversion libcurl4-openssl-dev libgnutls28-dev libsasl2-dev \
+    uuid-dev libtool libssl-dev libgcrypt20-dev libmicrohttpd-dev \
+    libltdl-dev libjson-c-dev libleptonica-dev libmosquitto-dev \
+    libunistring-dev dh-autoreconf sudo
+
+# Build from volkszaehler/vzlogger
+# pass "N" when prompted about adding systemd unit
+RUN mkdir /cfg && cd /tmp && \
+    git clone https://github.com/volkszaehler/vzlogger.git && \
+    cd vzlogger && \
+    echo "N\n" | bash ./install.sh
+
+# Setup volume 
+VOLUME ["/cfg"]
+
+# Run CMD when started
+CMD /usr/local/bin/vzlogger --config /cfg/vzlogger.conf

--- a/README.md
+++ b/README.md
@@ -48,11 +48,11 @@ Then run the installation:
 Docker
 ------
 
-You can also build a docker container:
+You can also build a docker image:
 
      docker build -t vzlogger .
      
-This will pull the newest vzlogger from volkszaehler github and build the container.
+Note, that this will use the newest vzlogger from volkszaehler github (not your local clone).
 You can start it:
 
      docker run --restart=always -v /home/pi/projects/vzlogger-docker:/cfg \

--- a/README.md
+++ b/README.md
@@ -44,6 +44,23 @@ Then run the installation:
 
     wget --no-check-certificate https://raw.github.com/volkszaehler/vzlogger/master/install.sh
     sudo bash install.sh
+    
+Docker
+------
+
+You can also build a docker container:
+
+     docker build -t vzlogger .
+     
+This will pull the newest vzlogger from volkszaehler github and build the container.
+You can start it:
+
+     docker run --restart=always -v /home/pi/projects/vzlogger-docker:/cfg \
+     --device=/dev/serial/by-id/usb-FTDI_FT230X_Basic_UART_D30A9U5N-if00-port0 \
+     --name vzlogger -d vzlogger
+
+where /home/pi/projects/vzlogger-docker is the path to the directory containing the vzlogger.conf file and
+/dev/serial/by-id/usb-FTDI_FT230X_Basic_UART_D30A8U6N-if00-port0 is your device. You can pass several devices if you have them.
 
 Mailing List
 -------------


### PR DESCRIPTION
To add vzlogger to home automation it is often sufficient to run vzlogger only with http push or MQTT. Most such environments are using docker these days, to avoid polluting the local OS with individual scattered install files - in some cases without an easy uninstall option, and with potentially lots of dependencies. 
This Dockerfile solves all that. 
P.S. it would be nice to add a flag to the install.sh to skip the systemd install request, to avoid passing "N".
Also maybe 

`docker build -t vzlogger .`

can be added in travis (and even pushed to docker hub directly for releases). 