### PR TITLE
remove meter_details_t.periodic

### DIFF
--- a/include/Meter.hpp
+++ b/include/Meter.hpp
@@ -93,7 +93,6 @@ typedef struct {
 	const char *name;          // short identifier for protocol
 	const char *desc;          // more detailed description
 	const size_t max_readings; // how many readings can be read with 1 call
-	const bool periodic;       // does this meter has be triggered periodically?
 } meter_details_t;
 
 /**

--- a/src/Meter.cpp
+++ b/src/Meter.cpp
@@ -49,7 +49,7 @@
 //#include <protocols/.h>
 
 #define METER_DETAIL(NAME, CLASSNAME, DESC, MAX_RDS, PERIODIC)                                     \
-	{ meter_protocol_##NAME, #NAME, DESC, MAX_RDS, PERIODIC /*, Meter##CLASSNAME */ }
+	{ meter_protocol_##NAME, #NAME, DESC, MAX_RDS, PERIODIC}
 
 int Meter::instances = 0;
 

--- a/src/Meter.cpp
+++ b/src/Meter.cpp
@@ -48,34 +48,31 @@
 #endif
 //#include <protocols/.h>
 
-#define METER_DETAIL(NAME, CLASSNAME, DESC, MAX_RDS, PERIODIC)                                     \
-	{ meter_protocol_##NAME, #NAME, DESC, MAX_RDS, PERIODIC}
+#define METER_DETAIL(NAME, CLASSNAME, DESC, MAX_RDS) \
+	{ meter_protocol_##NAME, #NAME, DESC, MAX_RDS}
 
 int Meter::instances = 0;
 
 static const meter_details_t protocols[] = {
-	/*  aliasdescriptionmax_rdsperiodic
-		===============================================================================================*/
-	METER_DETAIL(file, File, "Read from file or fifo", 32, false),
-	METER_DETAIL(exec, Exec, "Parse program output", 32, false),
-	METER_DETAIL(random, Random, "Generate random values with a random walk", 1, true),
-	METER_DETAIL(fluksov2, Fluksov2, "Read from Flukso's onboard SPI fifo", 16, false),
-	METER_DETAIL(s0, S0, "S0-meter directly connected to RS232", 4, false),
-	METER_DETAIL(d0, D0, "DLMS/IEC 62056-21 plaintext protocol", 400, false),
+	// name, alias, description, max_rds
+	METER_DETAIL(file, File, "Read from file or fifo", 32),
+	METER_DETAIL(exec, Exec, "Parse program output", 32),
+	METER_DETAIL(random, Random, "Generate random values with a random walk", 1),
+	METER_DETAIL(fluksov2, Fluksov2, "Read from Flukso's onboard SPI fifo", 16),
+	METER_DETAIL(s0, S0, "S0-meter directly connected to RS232", 4),
+	METER_DETAIL(d0, D0, "DLMS/IEC 62056-21 plaintext protocol", 400),
 #ifdef SML_SUPPORT
-	METER_DETAIL(sml, Sml, "Smart Message Language as used by EDL-21, eHz and SyM²", 32, false),
+	METER_DETAIL(sml, Sml, "Smart Message Language as used by EDL-21, eHz and SyM²", 32),
 #endif // SML_SUPPORT
 #ifdef OCR_SUPPORT
-	METER_DETAIL(ocr, OCR, "Image processing/recognizing meter", 32,
-				 false), // TODO periodic or not periodic?
+	METER_DETAIL(ocr, OCR, "Image processing/recognizing meter", 32),
 #endif
-	METER_DETAIL(w1therm, W1therm, "W1-therm / 1wire temperature devices", 400, false),
+	METER_DETAIL(w1therm, W1therm, "W1-therm / 1wire temperature devices", 400),
 #ifdef OMS_SUPPORT
-	METER_DETAIL(oms, OMS, "OMS (M-BUS) protocol based devices", 100,
-				 false), // todo what is the max. amount of reading according to spec?
+	METER_DETAIL(oms, OMS, "OMS (M-BUS) protocol based devices", 100),
 #endif
 	//{} /* stop condition for iterator */
-	METER_DETAIL(none, NULL, NULL, 0, false),
+	METER_DETAIL(none, NULL, NULL, 0),
 };
 
 Meter::Meter(std::list<Option> pOptions) : _name("meter") {
@@ -136,10 +133,7 @@ Meter::Meter(std::list<Option> pOptions) : _name("meter") {
 	}
 
 	try {
-		const meter_details_t *details = meter_get_details(_protocol_id);
-		if (details->periodic == true && _interval < 0) {
-			print(log_alert, "Interval has to be set and positive!", name());
-		}
+		(void) meter_get_details(_protocol_id);
 	} catch (vz::VZException &e) {
 		std::stringstream oss;
 		oss << e.what();

--- a/src/threads.cpp
+++ b/src/threads.cpp
@@ -81,12 +81,6 @@ void *reading_thread(void *arg) {
 					}
 				}
 
-				/* update buffer length with current interval */
-				// if (details->periodic == FALSE && delta > 0 && delta != mtr->interval()) {
-				// 	print(log_debug, "Updating interval to %i", mtr->name(), delta);
-				// 	mtr->interval(delta);
-				// }
-
 				/* insert readings into channel queues */
 				if (n > 0)
 					for (MeterMap::iterator ch = mapping->begin(); ch != mapping->end(); ch++) {


### PR DESCRIPTION
meter_details_t.periodic was supposed to indicate if a protocol
requires the reading delay/"period" to be define externally (via `interval`),
or if it limits the reading rate by itself.

this has been useless for a long time, because for many meters it depends
on the runtime configuration,
and actually a method to evaluate this at runtime has been introduced
as `allowInterval()` in https://github.com/volkszaehler/vzlogger/commit/cf3b67614b6c4d4ee801ce5df58fa58b6162975d, many years ago.