### PR TITLE
remove Reading::compare() (in addition to #422)

### DIFF
--- a/include/Reading.hpp
+++ b/include/Reading.hpp
@@ -45,18 +45,26 @@ class ReadingIdentifier {
 	virtual ~ReadingIdentifier(){};
 
 	virtual size_t unparse(char *buffer, size_t n) = 0;
-	bool operator==(ReadingIdentifier const &cmp) const;
+	bool operator==(ReadingIdentifier const &other) const { return other.isEqual(this); }
 	bool compare(ReadingIdentifier const *lhs, ReadingIdentifier const *rhs) const;
-
 	virtual const std::string toString() = 0;
 
   protected:
 	explicit ReadingIdentifier(){};
+	virtual bool isEqual(ReadingIdentifier const *other) const = 0;
 
   private:
 	// ReadingIdentifier (const ReadingIdentifier& original);
 	// ReadingIdentifier& operator= (const ReadingIdentifier& rhs);
 };
+
+namespace detail {
+template <class T> bool isEqual(const T &obj, const ReadingIdentifier *other) {
+	typedef typename std::add_pointer<typename std::add_const<T>::type>::type Pointer;
+	Pointer ptr(dynamic_cast<Pointer>(other));
+	return (ptr != nullptr) && (obj == *ptr);
+}
+} // namespace detail
 
 class ObisIdentifier : public ReadingIdentifier {
 
@@ -68,7 +76,8 @@ class ObisIdentifier : public ReadingIdentifier {
 	virtual ~ObisIdentifier(){};
 
 	size_t unparse(char *buffer, size_t n);
-	bool operator==(ObisIdentifier const &cmp) const;
+	bool operator==(ObisIdentifier const &other) const { return _obis == other.obis(); }
+
 	const std::string toString() {
 		std::ostringstream oss;
 		oss << "ObisIdentifier:" << _obis.toString();
@@ -82,6 +91,10 @@ class ObisIdentifier : public ReadingIdentifier {
 	// ObisIdentifier& operator= (const ObisIdentifier& rhs);
 
   protected:
+	virtual bool isEqual(const ReadingIdentifier *other) const {
+		return detail::isEqual(*this, other);
+	}
+
 	Obis _obis;
 };
 
@@ -92,7 +105,7 @@ class StringIdentifier : public ReadingIdentifier {
 
 	void parse(const char *buffer);
 	size_t unparse(char *buffer, size_t n);
-	bool operator==(StringIdentifier const &cmp) const;
+	bool operator==(StringIdentifier const &other) const { return _string == other._string; }
 	const std::string toString() {
 		std::ostringstream oss;
 		oss << "StringIdentifier:";
@@ -100,6 +113,10 @@ class StringIdentifier : public ReadingIdentifier {
 	};
 
   protected:
+	virtual bool isEqual(const ReadingIdentifier *other) const {
+		return detail::isEqual(*this, other);
+	}
+
 	std::string _string;
 };
 
@@ -111,7 +128,8 @@ class ChannelIdentifier : public ReadingIdentifier {
 
 	void parse(const char *string);
 	size_t unparse(char *buffer, size_t n);
-	bool operator==(ChannelIdentifier const &cmp) const;
+	bool operator==(ChannelIdentifier const &other) const { return _channel == other._channel; }
+
 	const std::string toString() {
 		std::ostringstream oss;
 		oss << "ChannelIdentifier:";
@@ -119,6 +137,10 @@ class ChannelIdentifier : public ReadingIdentifier {
 	};
 
   protected:
+	virtual bool isEqual(const ReadingIdentifier *other) const {
+		return detail::isEqual(*this, other);
+	}
+
 	int _channel;
 };
 
@@ -126,14 +148,17 @@ class NilIdentifier : public ReadingIdentifier {
   public:
 	NilIdentifier() {}
 	size_t unparse(char *buffer, size_t n);
-	bool operator==(NilIdentifier const &cmp) const;
+	// bool operator==(NilIdentifier const &cmp) const;
 	const std::string toString() {
 		std::ostringstream oss;
 		oss << "NilIdentifier";
 		return oss.str();
 	};
 
-  private:
+  protected:
+	virtual bool isEqual(const ReadingIdentifier *other) const {
+		return detail::isEqual(*this, other);
+	}
 };
 
 class Reading {

--- a/include/Reading.hpp
+++ b/include/Reading.hpp
@@ -46,7 +46,6 @@ class ReadingIdentifier {
 
 	virtual size_t unparse(char *buffer, size_t n) = 0;
 	bool operator==(ReadingIdentifier const &other) const { return other.isEqual(this); }
-	bool compare(ReadingIdentifier const *lhs, ReadingIdentifier const *rhs) const;
 	virtual const std::string toString() = 0;
 
   protected:

--- a/src/Reading.cpp
+++ b/src/Reading.cpp
@@ -149,38 +149,6 @@ size_t Reading::unparse(
 #endif
 }
 
-bool ReadingIdentifier::compare(ReadingIdentifier const *lhs, ReadingIdentifier const *rhs) const {
-	if (ObisIdentifier const *lhsx = dynamic_cast<ObisIdentifier const *>(lhs)) {
-		if (ObisIdentifier const *rhsx = dynamic_cast<ObisIdentifier const *>(rhs)) {
-			return *lhsx == *rhsx;
-		} else {
-			return false;
-		}
-	} else if (StringIdentifier const *lhsx = dynamic_cast<StringIdentifier const *>(lhs)) {
-		if (StringIdentifier const *rhsx = dynamic_cast<StringIdentifier const *>(rhs)) {
-			return *lhsx == *rhsx;
-		} else {
-			return false;
-		}
-	} else if (ChannelIdentifier const *lhsx = dynamic_cast<ChannelIdentifier const *>(lhs)) {
-		if (ChannelIdentifier const *rhsx = dynamic_cast<ChannelIdentifier const *>(rhs)) {
-			return *lhsx == *rhsx;
-		} else {
-			return false;
-		}
-	} else if (NilIdentifier const *lhsx = dynamic_cast<NilIdentifier const *>(lhs)) {
-		if (NilIdentifier const *rhsx = dynamic_cast<NilIdentifier const *>(rhs)) {
-			(void)lhsx;
-			(void)rhsx; // avoid compiler warning about unused vars.
-			return true;
-		} else {
-			return false;
-		}
-	}
-
-	return false;
-}
-
 size_t ObisIdentifier::unparse(char *buffer, size_t n) { return _obis.unparse(buffer, n); }
 
 /* StringIdentifier */

--- a/src/Reading.cpp
+++ b/src/Reading.cpp
@@ -149,10 +149,6 @@ size_t Reading::unparse(
 #endif
 }
 
-bool ReadingIdentifier::operator==(ReadingIdentifier const &cmp) const {
-	return this->compare(this, &cmp);
-}
-
 bool ReadingIdentifier::compare(ReadingIdentifier const *lhs, ReadingIdentifier const *rhs) const {
 	if (ObisIdentifier const *lhsx = dynamic_cast<ObisIdentifier const *>(lhs)) {
 		if (ObisIdentifier const *rhsx = dynamic_cast<ObisIdentifier const *>(rhs)) {
@@ -186,13 +182,8 @@ bool ReadingIdentifier::compare(ReadingIdentifier const *lhs, ReadingIdentifier 
 }
 
 size_t ObisIdentifier::unparse(char *buffer, size_t n) { return _obis.unparse(buffer, n); }
-bool ObisIdentifier::operator==(ObisIdentifier const &cmp) const { return (_obis == cmp.obis()); }
 
 /* StringIdentifier */
-bool StringIdentifier::operator==(StringIdentifier const &cmp) const {
-	return (_string == cmp._string);
-}
-
 void StringIdentifier::parse(const char *string) { _string = string; }
 
 size_t StringIdentifier::unparse(char *buffer, size_t n) {
@@ -208,10 +199,6 @@ size_t StringIdentifier::unparse(char *buffer, size_t n) {
 }
 
 /* ChannelIdentifier */
-bool ChannelIdentifier::operator==(ChannelIdentifier const &cmp) const {
-	return (_channel == cmp._channel);
-}
-
 void ChannelIdentifier::parse(const char *string) {
 	char type[13];
 	int channel;


### PR DESCRIPTION
optimistically based on #422  .
remove the Reading::compare() method that is made obsolete by #422