### PR TITLE
Add docker action

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,35 @@
+name: docker
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set versions env var
+        run: sed -n -e 's/.*\(VZLOGGER_.*_VERSION\) \+\([0-9]\+\).*/\1=\2/p' CMakeLists.txt >> $GITHUB_ENV
+      - name: Set env sha short
+        run: echo "GITHUB_SHA_SHORT=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          platforms: linux/amd64,linux/arm/v6
+          tags: ${{ env.image_name }}:commit-${{ env.GITHUB_SHA_SHORT }}, ${{ env.image_name }}:${{ env.VZLOGGER_MAJOR_VERSION }}.${{ env.VZLOGGER_MINOR_VERSION }}.${{ env.VZLOGGER_SUB_VERSION }}, ${{ env.image_name }}:${{ env.VZLOGGER_MAJOR_VERSION }}.${{ env.VZLOGGER_MINOR_VERSION }}, ${{ env.image_name }}:${{ env.VZLOGGER_MAJOR_VERSION }}, ${{ env.image_name }}:latest
+        env:
+          image_name: ${{ secrets.DOCKERHUB_USERNAME }}/vzlogger

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,8 +16,6 @@ jobs:
       - name: Set env sha short
         run: echo "GITHUB_SHA_SHORT=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Login to DockerHub
@@ -29,7 +27,6 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
-          platforms: linux/amd64,linux/arm/v6
           tags: ${{ env.image_name }}:commit-${{ env.GITHUB_SHA_SHORT }}, ${{ env.image_name }}:${{ env.VZLOGGER_MAJOR_VERSION }}.${{ env.VZLOGGER_MINOR_VERSION }}.${{ env.VZLOGGER_SUB_VERSION }}, ${{ env.image_name }}:${{ env.VZLOGGER_MAJOR_VERSION }}.${{ env.VZLOGGER_MINOR_VERSION }}, ${{ env.image_name }}:${{ env.VZLOGGER_MAJOR_VERSION }}, ${{ env.image_name }}:latest
         env:
           image_name: ${{ secrets.DOCKERHUB_USERNAME }}/vzlogger


### PR DESCRIPTION
Add a github docker build action.
This is my first github action, so please give much feedback as possible ;)
This requires to set the `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` secrets.
This is building a multi arch image for the linux/amd64, linux/arm64, linux/arm/v7, linux/arm/v6 platforms.
It extract the version from the `CMAKELists.txt`. The image will get a list of tags: latest, the major version, the major and minor version, the major, minor and sub version and also the commit id. So we have `vzlogger:latest`, `vzlogger:0`, `vzlogger:0.8`, `vzlogger:0.8.0` and `vzlogger:commit-<shortcommitid>`. I add the commit version, because currently no incrementing version number exists and this allows in a case of a problem to go back to a previous version.
I pushed this to test the process to https://hub.docker.com/r/stefanschoof/vzlogger/tags
This action is trigger on every push and pr, but only if a commit to the master branch the images will pushed to docker hub. I think with this approach it is possible to find build breaks on other platforms quicker. Building all platform images will take up to 30 mins.
A sample pr run https://github.com/StefanSchoof/vzlogger/runs/2243563277?check_suite_focus=true
A sample master branch run https://github.com/StefanSchoof/vzlogger/runs/2244080338?check_suite_focus=true
I tried a cache, but since this would cache the libsml and libmbus builds, I deiced against it.