### PR TITLE
reject readings with really old timestamps, ...

### DIFF
--- a/include/Config_Options.hpp
+++ b/include/Config_Options.hpp
@@ -79,6 +79,8 @@ class Config_Options {
 
 	bool doRegistration() const { return _doRegistration; }
 
+	bool haveTimeMachine() const { return _time_machine; }
+
 	// setter
 	void config(const std::string &v) { _config = v; }
 	void log(const std::string &v) { _log = v; }
@@ -94,6 +96,8 @@ class Config_Options {
 	void foreground(const bool v) { _foreground = v; }
 
 	void doRegistration(const bool v) { _doRegistration = v; }
+
+	void haveTimeMachine(const bool v) { _time_machine = v; }
 
 	PushDataServer *pushDataServer() const { return _pds; }
 
@@ -114,6 +118,7 @@ class Config_Options {
 	int _local : 1;          // enable local interface
 	int _foreground : 1;     // don't daemonize
 	int _doRegistration : 1; // FIXME
+	int _time_machine : 1;   // accept readings from before smart-metering existed
 };
 
 /**

--- a/src/Config_Options.cpp
+++ b/src/Config_Options.cpp
@@ -41,13 +41,15 @@ static const char *option_type_str[] = {"null",   "boolean", "double", "int",
 
 Config_Options::Config_Options()
 	: _config("/etc/vzlogger.conf"), _log(""), _pds(0), _port(8080), _verbosity(0),
-	  _comet_timeout(30), _buffer_length(-1), _retry_pause(15), _local(false), _foreground(false) {
+	  _comet_timeout(30), _buffer_length(-1), _retry_pause(15), _local(false), _foreground(false),
+	  _time_machine(false) {
 	_logfd = NULL;
 }
 
 Config_Options::Config_Options(const std::string filename)
 	: _config(filename), _log(""), _pds(0), _port(8080), _verbosity(0), _comet_timeout(30),
-	  _buffer_length(-1), _retry_pause(15), _local(false), _foreground(false) {
+	  _buffer_length(-1), _retry_pause(15), _local(false), _foreground(false),
+	  _time_machine(false) {
 	_logfd = NULL;
 }
 
@@ -178,7 +180,9 @@ void Config_Options::config_parse(MapContainer &mappings) {
 						  "mqtt");
 			}
 #endif
-			else {
+			else if ((strcmp(key, "i_have_a_time_machine") == 0) && type == json_type_boolean) {
+				_time_machine = json_object_get_boolean(value);
+			} else {
 				print(log_alert, "Ignoring invalid field or type: %s=%s (%s)", NULL, key,
 					  json_object_get_string(value), option_type_str[type]);
 			}

--- a/src/threads.cpp
+++ b/src/threads.cpp
@@ -80,6 +80,27 @@ void *reading_thread(void *arg) {
 							  rds[i].time_ms());
 					}
 				}
+				if (n > 0 && !options.haveTimeMachine())
+					for (size_t i = 0; i < n; i++)
+						if (rds[i].time_s() < 631152000) { // 1990-01-01 00:00:00
+							print(log_error,
+								  "meter returned readings with a timestamp before 1990, IGNORING.",
+								  mtr->name());
+							print(log_error, "most likely your meter is misconfigured,",
+								  mtr->name());
+							print(log_error,
+								  "for sml meters, set `\"use_local_time\": true` in vzlogger.conf"
+								  " (meter section),",
+								  mtr->name());
+							print(log_error,
+								  "to override this check, set `\"i_have_a_time_machine\": true`"
+								  " in vzlogger.conf.",
+								  mtr->name());
+							// note: we do NOT throw an exception or such,
+							// because this might be a spurious error,
+							// the next reading might be valid again.
+							n = 0;
+						}
 
 				/* insert readings into channel queues */
 				if (n > 0)


### PR DESCRIPTION
these usually occur when a meter is sending timestamps but does not have
it's clock set properly, typically returning seconds since power-up
instead of seconds since the unix epoch (1970-01-01).
this often causes confusion, which can be easily avoided.

i arbitrarily picked 1990-01-01 as a cut-off point,
for one, few or no smart meters should have existed back then,
so nobody will be trying to read archived data that old,
for another a meter counting it's uptime would need twenty
years of uptime to generate a timestamp that is accepted.

for any obscure corner cases, a config option:
	"i_have_a_time_machine"
is availableto disable the check.


(example: #488 )