### PR TITLE
[api/influxdb] fix memory leak (fixup 6ab1bb7d)

### DIFF
--- a/include/api/InfluxDB.hpp
+++ b/include/api/InfluxDB.hpp
@@ -57,6 +57,7 @@ class InfluxDB : public ApiIF {
 	std::string _host;
 	std::string _username;
 	std::string _token;
+	struct curl_slist *_token_header;
 	std::string _organization;
 	std::string _password;
 	std::string _database;


### PR DESCRIPTION
also create header and header-list only once.
(previous code leaked one curl_slist struct per send() invocation)

probably fixes #513 