### PR TITLE
Zero-initialize vendor+identifier in MeterD0

### DIFF
--- a/src/protocols/MeterD0.cpp
+++ b/src/protocols/MeterD0.cpp
@@ -378,9 +378,9 @@ ssize_t MeterD0::read(std::vector<Reading> &rds, size_t max_readings) {
 
 	bool error_flag = false;
 	const int VENDOR_LEN = 3;
-	char vendor[VENDOR_LEN + 1]; // 3 upper case vendor + '\0' termination
+	char vendor[VENDOR_LEN + 1] = {0}; // 3 upper case vendor + '\0' termination
 	const int IDENTIFICATION_LEN = 16;
-	char identification[IDENTIFICATION_LEN + 1]; // 16 meter specific + '\0' termination
+	char identification[IDENTIFICATION_LEN + 1] = {0}; // 16 meter specific + '\0' termination
 	const int OBIS_LEN = 16;
 	char obis_code[OBIS_LEN + 1]; /* A-B:C.D.E*F
 							 fields A, B, E, F are optional


### PR DESCRIPTION
This fixes a read from uninitialized stack memory in logging when a
frame was terminated before reading these values, for example when
receiving only "/!".

To reproduce, do something like this:
![Bildschirmfoto 2022-05-21 um 09 23 05](https://user-images.githubusercontent.com/1460997/169640967-e7ef92f6-d9f4-47e6-9108-e4e8e87d2db4.png)
