### PR TITLE
Fix type for a printf-style size_t arg in MeterD0

### DIFF
--- a/src/protocols/MeterD0.cpp
+++ b/src/protocols/MeterD0.cpp
@@ -757,8 +757,9 @@ ssize_t MeterD0::read(std::vector<Reading> &rds, size_t max_readings) {
 			}
 
 			print(log_debug,
-				  "Read package with %i tuples (vendor=%s, baudrate=%c, identification=%s)",
-				  name().c_str(), number_of_tuples, vendor, baudrate, identification);
+				  "Read package with %llu tuples (vendor=%s, baudrate=%c, identification=%s)",
+				  name().c_str(), (unsigned long long)number_of_tuples, vendor, baudrate,
+				  identification);
 			return number_of_tuples;
 		} // end switch
 


### PR DESCRIPTION
number_of_tuples is size_t, but %i expects int. Since %z is less
compatible, %llu can be used here with a cast.