### PR TITLE
reading_thread: Only allow cancellation at defined points

### DIFF
--- a/src/threads.cpp
+++ b/src/threads.cpp
@@ -44,6 +44,19 @@
 
 extern Config_Options options;
 
+inline void _safe_to_cancel() {
+	// see https://blog.memzero.de/pthread-cancel-noexcept/
+	pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, NULL);
+	pthread_testcancel();
+	pthread_setcancelstate(PTHREAD_CANCEL_DISABLE, NULL);
+}
+
+inline void _cancellable_sleep(int seconds) {
+	pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, NULL);
+	sleep(seconds);
+	pthread_setcancelstate(PTHREAD_CANCEL_DISABLE, NULL);
+}
+
 void *reading_thread(void *arg) {
 	MeterMap *mapping = static_cast<MeterMap *>(arg);
 	Meter::Ptr mtr = mapping->meter();
@@ -52,9 +65,12 @@ void *reading_thread(void *arg) {
 	size_t n = 0;
 	bool first_reading = true;
 
+	// Only allow cancellation at safe points
+	pthread_setcancelstate(PTHREAD_CANCEL_DISABLE, NULL);
+	pthread_setcanceltype(PTHREAD_CANCEL_DEFERRED, NULL);
+
 	details = meter_get_details(mtr->protocolId());
 	std::vector<Reading> rds(details->max_readings, Reading(mtr->identifier()));
-	;
 
 	print(log_debug, "Number of readers: %d", mtr->name(), details->max_readings);
 	print(log_debug, "Config.local: %d", mtr->name(), options.local());
@@ -62,15 +78,17 @@ void *reading_thread(void *arg) {
 	try {
 		aggIntEnd = time(NULL);
 		do { /* start thread main loop */
+			_safe_to_cancel();
 			do {
 				aggIntEnd += mtr->aggtime(); /* end of this aggregation period */
 			} while ((aggIntEnd < time(NULL)) && (mtr->aggtime() > 0));
 			do { /* aggregate loop */
-
-				if (mtr->interval() > 0 && !first_reading) {
+				_safe_to_cancel();
+				int interval = mtr->interval();
+				if (interval > 0 && !first_reading) {
 					print(log_info, "waiting %i seconds before next reading", mtr->name(),
-						  mtr->interval());
-					sleep(mtr->interval());
+						  interval);
+					_cancellable_sleep(interval);
 				}
 				first_reading = false;
 


### PR DESCRIPTION
This is needed to properly support pthread_cancel(), which causes the metermap test to fail every so often with the error "terminate called without an active exception"

https://blog.memzero.de/pthread-cancel-noexcept/ has a good explanation on why this works.