### PR TITLE
Support for OpenSSL 3.0+

### DIFF
--- a/include/api/MySmartGrid.hpp
+++ b/include/api/MySmartGrid.hpp
@@ -83,8 +83,6 @@ class MySmartGrid : public ApiIF {
 
 	void _api_header();
 
-	void hmac_sha1(char *digest, const unsigned char *data, size_t dataLen);
-
 	CurlResponse *response() { return _response.get(); }
 
 	void convertUuid(const std::string uuidIn, std::string &uuidOut);

--- a/include/api/hmac.h
+++ b/include/api/hmac.h
@@ -1,0 +1,12 @@
+#ifndef __hmac_h_
+#define __hmac_h_
+
+#include <stddef.h>
+
+namespace vz {
+void hmac_sha1(char *digest, const unsigned char *data, size_t dataLen,
+			   const unsigned char *secretKey, size_t secretLen);
+
+} // namespace vz
+
+#endif

--- a/src/api/CMakeLists.txt
+++ b/src/api/CMakeLists.txt
@@ -9,6 +9,7 @@ set(api_srcs
   CurlIF.cpp
   CurlCallback.cpp
   CurlResponse.cpp
+  hmac.cpp
 )
 
 add_library(vz-api ${api_srcs})

--- a/src/api/hmac.cpp
+++ b/src/api/hmac.cpp
@@ -1,0 +1,63 @@
+#include <cstring>
+#include <openssl/evp.h>
+#include <openssl/hmac.h>
+#include <openssl/sha.h>
+#include <openssl/ssl.h>
+
+namespace vz {
+
+void hmac_sha1(char *digest, const unsigned char *data, size_t dataLen,
+			   const unsigned char *secretKey, size_t secretLen) {
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+	HMAC_CTX hmacContext;
+
+	HMAC_Init(&hmacContext, secretKey(), secretLen), EVP_sha1());
+	HMAC_Update(&hmacContext, data, dataLen);
+#elif OPENSSL_VERSION_NUMBER < 0x30000000L
+	HMAC_CTX *hmacContext = HMAC_CTX_new();
+
+	HMAC_Init_ex(hmacContext, secretKey, secretLen, EVP_sha1(), NULL);
+	HMAC_Update(hmacContext, data, dataLen);
+#else
+	EVP_MD_CTX *evpContext = EVP_MD_CTX_new();
+	EVP_PKEY *pkey = EVP_PKEY_new_raw_private_key(EVP_PKEY_HMAC, NULL, secretKey, secretLen);
+	EVP_DigestSignInit(evpContext, NULL, EVP_sha1(), NULL, pkey);
+	EVP_PKEY_free(pkey);
+	EVP_DigestSignUpdate(evpContext, data, dataLen);
+#endif
+
+	unsigned char out[EVP_MAX_MD_SIZE];
+
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+	unsigned int len = EVP_MAX_MD_SIZE;
+	HMAC_Final(&hmacContext, out, &len);
+#elif OPENSSL_VERSION_NUMBER < 0x30000000L
+	unsigned int len = EVP_MAX_MD_SIZE;
+	HMAC_Final(hmacContext, out, &len);
+#else
+	size_t len = EVP_MAX_MD_SIZE;
+	EVP_DigestSignFinal(evpContext, out, &len);
+#endif
+
+	char ret[2 * EVP_MAX_MD_SIZE];
+	memset(ret, 0, sizeof(ret));
+
+	for (size_t i = 0; i < len; i++) {
+		char s[4];
+		snprintf(s, 3, "%02x",
+				 out[i]); // format string was "%02x:" but size was only 3 so last : was not printed
+		strncat(ret, s, 2 * len);
+		// strncat(ret, s, sizeof(ret));
+	}
+	snprintf(digest, 255 /*sizeof(digest)*/, "X-Digest: %s", ret);
+
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+	// Nothing to free
+#elif OPENSSL_VERSION_NUMBER < 0x30000000L
+	HMAC_CTX_free(hmacContext);
+#else
+	EVP_MD_CTX_free(evpContext);
+#endif
+}
+
+} // namespace vz

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,6 +10,7 @@ list(APPEND test_sources
     ../src/api/Volkszaehler.cpp
     ../src/CurlSessionProvider.cpp
     ../src/protocols/MeterW1therm.cpp
+    ../src/api/hmac.cpp
 )
 
 set(test_libraries
@@ -24,6 +25,7 @@ set(test_libraries
     unistring
     ${GNUTLS_LIBRARIES}
     ${OCR_LIBRARIES}
+    ${OPENSSL_LIBRARIES}
 )
 
 if(SML_FOUND AND ENABLE_SML)
@@ -53,7 +55,7 @@ endif(ENABLE_MQTT)
 
 if(OMS_SUPPORT)
     list(APPEND test_sources ../src/protocols/MeterOMS.cpp)
-    list(APPEND test_libraries ${MBUS_LIBRARY} ${OPENSSL_LIBRARIES})
+    list(APPEND test_libraries ${MBUS_LIBRARY})
 endif(OMS_SUPPORT)
 
 add_executable(vzlogger_unit_tests ${test_sources})

--- a/tests/mocks/CMakeLists.txt
+++ b/tests/mocks/CMakeLists.txt
@@ -39,6 +39,7 @@ add_executable(mock_metermap
 	../../src/ltqnorm.cpp
 	../../src/MeterMap.cpp
 	../../src/threads.cpp
+	../../src/api/hmac.cpp
 	../../src/Config_Options.cpp
 	../../src/Buffer.cpp
 	../../src/api/Volkszaehler.cpp

--- a/tests/ut_api_hmac.cpp
+++ b/tests/ut_api_hmac.cpp
@@ -1,0 +1,17 @@
+
+#include <api/hmac.h>
+
+#include "gtest/gtest.h"
+using namespace testing;
+
+TEST(api_hmac, simple_digest) {
+
+	char digest[256];
+	unsigned char *data = (unsigned char *)"Test";
+	size_t datalen = 4;
+	unsigned char *secretkey = (unsigned char *)"secret";
+	size_t secretlen = 6;
+
+	vz::hmac_sha1(digest, data, datalen, secretkey, secretlen);
+	ASSERT_STREQ(digest, "X-Digest: fdaa1009d29b3de5e4fa6b0f31226ead23e34c25");
+}


### PR DESCRIPTION
This patch adds support for openssl 3.0 and later. 

It also moves the sha1 calculation into its own file to enable testing.

Code is heavily inspired by https://gitlab.isc.org/isc-projects/kea/-/merge_requests/1582/diffs#0592d076cdc8b76110bb63b48b37ca2416ad31c4