### PR TITLE
Fix gtest version

### DIFF
--- a/gtest/CMakeLists.txt.in
+++ b/gtest/CMakeLists.txt.in
@@ -5,7 +5,7 @@ project(gtest-download NONE)
 include(ExternalProject)
 ExternalProject_Add(googletest
   GIT_REPOSITORY    https://github.com/google/googletest.git
-  GIT_TAG           main
+  GIT_TAG           release-1.12.1
   SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/gtest-src"
   BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/gtest-build"
   CONFIGURE_COMMAND ""


### PR DESCRIPTION
Using the latest released gtest version works. The current main version has a bug which causes it to fail on most compilers. This fixes gtest to a given version, thus avoiding random failures