### PR TITLE
don't fail on deprecated-declarations in gcc build,

### DIFF
--- a/modules/CompilerFlags.cmake
+++ b/modules/CompilerFlags.cmake
@@ -9,6 +9,8 @@ if(NOT WIN32)
     include (CheckCXXSourceCompiles)
 
     set(CMAKE_CXX_FLAGS "${CXXFLAGS} -W -Wall -Wextra -Werror -Wnon-virtual-dtor -Wno-system-headers")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-declarations")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Winit-self -Wmissing-include-dirs -Wno-pragmas -Wredundant-decls")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-parameter -std=c++11")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fpermissive")


### PR DESCRIPTION
align with clang build config,
workaround failure due to depreciation of HMAC in OpenSSL 3.0

quickest possible fix for #530, #554