### PR TITLE
docker alpine based image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,7 @@
+# docker related
+.dockerignore
+Dockerfile
+
 *~
 
 # Binaries

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,8 @@ RUN apk add --no-cache \
     mosquitto-dev \
     libunistring-dev \
     automake \
-    autoconf
+    autoconf \
+    gtest-dev
 
 WORKDIR /vzlogger
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,79 +1,80 @@
-ARG DEBIAN_VERSION=buster-slim
-
 ############################
 # STEP 1 build executable binary
 ############################
 
-FROM debian:$DEBIAN_VERSION as builder
+FROM alpine:latest as builder
 
-RUN apt-get update && apt-get install -y \
-    build-essential \
-    git-core \
+RUN apk add --no-cache \
+    gcc \
+    g++ \
+    libc-dev \
+    linux-headers \
+    git \
+    make \
     cmake \
-    pkg-config \
-    libcurl4-openssl-dev \
-    libgnutls28-dev \
-    libsasl2-dev \
-    uuid-dev \
+    curl-dev \
+    gnutls-dev \
+    cyrus-sasl-dev \
+    # for libuuid
+    util-linux-dev \
     libtool \
-    libssl-dev \
-    libgcrypt20-dev \
+    libgcrypt-dev \
     libmicrohttpd-dev \
-    libltdl-dev \
-    libjson-c-dev \
-    libleptonica-dev \
-    libmosquitto-dev \
+    json-c-dev \
+    mosquitto-dev \
     libunistring-dev \
-    dh-autoreconf \
-    && rm -rf /var/lib/apt/lists/*
+    automake \
+    autoconf
 
 WORKDIR /vzlogger
 
 RUN git clone https://github.com/volkszaehler/libsml.git --depth 1 \
- && make install -C libsml/sml
+    && make install -C libsml/sml
 
 RUN git clone https://github.com/rscada/libmbus.git --depth 1 \
- && cd libmbus \
- && ./build.sh \
- && make install
+    && cd libmbus \
+    && ./build.sh \
+    && make install
 
 COPY . /vzlogger
 
-RUN cmake -DBUILD_TEST=off \
- && make \
- && make install
+ARG build_test=off
+RUN cmake -DBUILD_TEST=${build_test} \
+    && make \
+    && make install \
+    && if [ "$build_test" != "off" ]; then make test; fi
 
 
 #############################
 ## STEP 2 build a small image
 #############################
 
-FROM debian:$DEBIAN_VERSION
+FROM alpine:latest
 
 LABEL Description="vzlogger"
 
-RUN apt-get update && apt-get install -y \
-    libcurl4 \
-    libgnutls30 \
-    libsasl2-2  \
-    libuuid1 \
-    libssl1.1 \
-    libgcrypt20  \
-    libmicrohttpd12 \
-    libltdl7 \
-    libatomic1 \
-    libjson-c3 \
-    liblept5 \
-    libmosquitto1 \
-    libunistring2 \
-    && rm -rf /var/lib/apt/lists/*
+RUN apk add --no-cache \
+    libcurl \
+    gnutls \
+    libsasl \
+    libuuid \
+    libgcrypt \
+    libmicrohttpd \
+    json-c \
+    libatomic \
+    mosquitto-libs \
+    libunistring \
+    libstdc++ \
+    libgcc
 
 # libsml is linked statically => no need to copy
 COPY --from=builder /usr/local/bin/vzlogger /usr/local/bin/vzlogger
 COPY --from=builder /usr/local/lib/libmbus.so* /usr/local/lib/
 
 # without running a user context, no exec is possible and without the dialout group no access to usb ir reader possible
-RUN useradd -M -G dialout vz
-USER vz
+RUN adduser -S vz -G dialout
 
+RUN vzlogger --version
+
+USER vz
 CMD ["vzlogger", "--foreground"]


### PR DESCRIPTION
In #545 the idea of an alpine based docker image come up.

In #560 a PR from @maxberger adding a alpine based image was added by mistake. 

I took this commit from @maxberger and cleaned the file up.

Building with a amd64 image with `docker build --pull .` is working. 

But the arm build `docker build --pull --platform=linux/arm/v6 .` fails:

```
------                                                                                  
 > [builder 8/8] RUN cmake -DBUILD_TEST=off     && make     && make install:            
#13 0.639 CMake Warning:                                                                
#13 0.639   No source or binary directory provided.  Both will be assumed to be the
#13 0.639   same as the current working directory, but note that this warning will
#13 0.639   become a fatal error in future CMake releases.
#13 0.639 
#13 0.640 
#13 1.436 -- The C compiler identification is GNU 12.2.1
#13 2.157 -- The CXX compiler identification is GNU 12.2.1
#13 2.261 -- Detecting C compiler ABI info
#13 3.271 -- Detecting C compiler ABI info - done
#13 3.379 -- Check for working C compiler: /usr/bin/cc - skipped
#13 3.381 -- Detecting C compile features
#13 3.386 -- Detecting C compile features - done
#13 3.418 -- Detecting CXX compiler ABI info
#13 4.385 -- Detecting CXX compiler ABI info - done
#13 4.490 -- Check for working CXX compiler: /usr/bin/c++ - skipped
#13 4.492 -- Detecting CXX compile features
#13 4.499 -- Detecting CXX compile features - done
#13 4.506 CMake Deprecation Warning at CMakeLists.txt:3 (cmake_minimum_required):
#13 4.506   Compatibility with CMake < 2.8.12 will be removed from a future version of
#13 4.506   CMake.
#13 4.506 
#13 4.506   Update the VERSION argument <min> value or use a ...<max> suffix to tell
#13 4.506   CMake that the project does not need compatibility with older versions.
#13 4.506 
#13 4.506 
#13 4.714 Compiling for target ''
#13 4.715 -- using gcc compiler GNU
#13 4.718 -- checking if -Wno-ignored-qualifiers works
#13 4.719 -- Performing Test W_NO_IGNORED_QUALIFIERS
#13 5.650 -- Performing Test W_NO_IGNORED_QUALIFIERS - Success
#13 5.655 -- Performing Test HAVE_CPP_REGEX
#13 24.99 -- Performing Test HAVE_CPP_REGEX - Success
#13 25.00 -- FindSml check
#13 25.03 -- Found PkgConfig: /usr/bin/pkg-config (found version "1.9.3") 
#13 25.04 -- Checking for module 'sml>=1.0'
#13 25.07 --   Package 'sml', required by 'virtual:world', not found
#13 25.07 -- SML_HOME env is not set, setting it to /usr/local
#13 25.07 -- Looking for sml in /usr/local
#13 25.08 -- FindMBus check
#13 25.11 -- Checking for module 'libmbus>=0.8.0'
#13 25.24 --   Found libmbus, version 0.9.0
#13 25.63 -- Looking for libmbus in /usr/local/include
#13 25.63 libmbus found: '/usr/local/include'
#13 26.21 -- Found OpenSSL: /usr/lib/libcrypto.so (found version "3.0.7")  
#13 26.22 -- FindMicrohttpd check
#13 26.25 -- Checking for module 'microhttpd>=0.9'
#13 26.28 --   Package 'microhttpd', required by 'virtual:world', not found
#13 26.29 -- MICROHTTPD_HOME env is not set, setting it to /usr/local
#13 26.29 -- Looking for microhttpd in /usr/local
#13 26.29 -- search for libmosquitto returned /usr/lib/libmosquitto.so and /usr/include
#13 26.29 -- libmosquitto found at /usr/lib/libmosquitto.so
#13 26.30 -- Performing Test CMAKE_HAVE_LIBC_PTHREAD
#13 27.26 -- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Success
#13 27.27 -- Found Threads: TRUE  
#13 27.27 -- FindJson check
#13 27.31 -- Checking for module 'json-c>=0.12'
#13 27.43 --   Found json-c, version 0.16
#13 27.78 -- JSON_HOME env is not set, setting it to /usr/local
#13 27.78 -- Looking for json in /usr/local
#13 27.78 Json-c search: '/usr/local/include;/usr/local/include;/usr/local/include;/usr/include' 
#13 27.78 Json-c found: '/usr/include'
#13 28.50 -- Found CURL: /usr/lib/libcurl.so (found version "7.87.0")  
#13 28.50 -- FindGnuTls check
#13 28.55 -- Checking for module 'gnutls>=2.8'
#13 28.68 --   Found gnutls, version 3.7.8
#13 29.08 -- ==> ''
#13 29.08 -- GNUTLS_HOME env is not set, setting it to /usr/local
#13 29.08 -- Looking for gnutls in /usr/local
#13 29.10 ==> GNUTLS_LIBRARIES='-lgnutls;/usr/lib/libgmp.a;-lunistring;/usr/lib/libatomic.a;-lnettle;-lhogweed;/usr/lib/libgmp.a;-ltasn1;-lp11-kit;-lz;-lsasl2;-lgcrypt'
#13 29.10 -- Found GNUTLS: -lgnutls;/usr/lib/libgmp.a;-lunistring;/usr/lib/libatomic.a;-lnettle;-lhogweed;/usr/lib/libgmp.a;-ltasn1;-lp11-kit;-lz;-lsasl2;-lgcrypt  
#13 29.27 -- Found Git: /usr/bin/git (found version "2.38.2") 
#13 29.32 
#13 29.32         ***** Configuration parameters *****
#13 29.32              prefix: /usr/local
#13 29.32              json: -L/usr/lib/libjson-c.a;-lrt -I/usr/include
#13 29.32              sml:  -L/usr/local/lib/libsml.a;-lrt -I/usr/local/include
#13 29.32              microhttpd: -L/usr/lib/libmicrohttpd.so;-lrt -I/usr/include
#13 29.32              mqtt: -L/usr/lib/libmosquitto.so -I/usr/include
#13 29.32              libmbus: -L/usr/local/lib/libmbus.so;-lm -I/usr/local/include
#13 29.47 -- Configuring done
#13 29.67 -- Generating done
#13 29.69 -- Build files have been written to: /vzlogger
#13 29.74 /usr/bin/cmake -S/vzlogger -B/vzlogger --check-build-system CMakeFiles/Makefile.cmake 0
#13 29.89 /usr/bin/cmake -E cmake_progress_start /vzlogger/CMakeFiles /vzlogger//CMakeFiles/progress.marks
#13 29.98 make  -f CMakeFiles/Makefile2 all
#13 30.02 make[1]: Entering directory '/vzlogger'
#13 30.02 make  -f src/CMakeFiles/vz.dir/build.make src/CMakeFiles/vz.dir/depend
#13 30.05 make[2]: Entering directory '/vzlogger'
#13 30.05 cd /vzlogger && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /vzlogger /vzlogger/src /vzlogger /vzlogger/src /vzlogger/src/CMakeFiles/vz.dir/DependInfo.cmake --color=
#13 30.17 make[2]: Leaving directory '/vzlogger'
#13 30.17 make  -f src/CMakeFiles/vz.dir/build.make src/CMakeFiles/vz.dir/build
#13 30.20 make[2]: Entering directory '/vzlogger'
#13 30.28 [  2%] Building CXX object src/CMakeFiles/vz.dir/Channel.cpp.o
#13 30.29 cd /vzlogger/src && /usr/bin/c++ -DHAVE_CONFIG_HPP -I/vzlogger -I/vzlogger/include -W -Wall -Wextra -Werror -Wnon-virtual-dtor -Wno-system-headers -Wno-deprecated -Wno-deprecated-declarations -Winit-self -Wmissing-include-dirs -Wno-pragmas -Wredundant-decls -Wno-unused-parameter -std=c++11 -fpermissive -Wno-error=redundant-decls -Wno-ignored-qualifiers   -g3 -MD -MT src/CMakeFiles/vz.dir/Channel.cpp.o -MF CMakeFiles/vz.dir/Channel.cpp.o.d -o CMakeFiles/vz.dir/Channel.cpp.o -c /vzlogger/src/Channel.cpp
#13 33.36 In file included from /vzlogger/include/Buffer.hpp:35,
#13 33.36                  from /vzlogger/include/Channel.hpp:32,
#13 33.36                  from /vzlogger/src/Channel.cpp:35:
#13 33.36 /vzlogger/include/Reading.hpp: In member function 'const long int& Reading::time_s() const':
#13 33.36 /vzlogger/include/Reading.hpp:182:30: error: returning reference to temporary [-Werror=return-local-addr]
#13 33.36   182 |                 return _time.tv_sec;
#13 33.36       |                        ~~~~~~^~~~~~
#13 34.43 In file included from /usr/include/c++/12.2.1/list:63,
#13 34.43                  from /vzlogger/include/Buffer.hpp:31:
#13 34.43 /usr/include/c++/12.2.1/bits/stl_list.h: In copy constructor 'std::__cxx11::list<_Tp, _Alloc>::list(const std::__cxx11::list<_Tp, _Alloc>&) [with _Tp = Option; _Alloc = std::allocator<Option>]':
#13 34.43 /usr/include/c++/12.2.1/bits/stl_list.h:814:31: note: parameter passing for argument of type 'std::_List_const_iterator<Option>' changed in GCC 7.1
#13 34.43   814 |       { _M_initialize_dispatch(__x.begin(), __x.end(), __false_type()); }
#13 34.43       |         ~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#13 34.50 /usr/include/c++/12.2.1/bits/stl_list.h: In member function 'void std::__cxx11::list<_Tp, _Alloc>::_M_initialize_dispatch(_InputIterator, _InputIterator, std::__false_type) [with _InputIterator = std::_List_const_iterator<Option>; _Tp = Option; _Alloc = std::allocator<Option>]':
#13 34.50 /usr/include/c++/12.2.1/bits/stl_list.h:1929:9: note: parameter passing for argument of type 'std::_List_const_iterator<Option>' changed in GCC 7.1
#13 34.50  1929 |         _M_initialize_dispatch(_InputIterator __first, _InputIterator __last,
#13 34.50       |         ^~~~~~~~~~~~~~~~~~~~~~
#13 34.50 /usr/include/c++/12.2.1/bits/stl_list.h:1929:9: note: parameter passing for argument of type 'std::_List_const_iterator<Option>' changed in GCC 7.1
#13 34.56 /usr/include/c++/12.2.1/bits/stl_list.h: In member function 'void std::__cxx11::list<_Tp, _Alloc>::emplace_back(_Args&& ...) [with _Args = {const Option&}; _Tp = Option; _Alloc = std::allocator<Option>]':
#13 34.56 /usr/include/c++/12.2.1/bits/stl_list.h:1321:26: note: parameter passing for argument of type 'std::_List_iterator<Option>' changed in GCC 7.1
#13 34.56  1321 |           this->_M_insert(end(), std::forward<_Args>(__args)...);
#13 34.56       |           ~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#13 34.60 /usr/include/c++/12.2.1/bits/stl_list.h: In member function 'void std::__cxx11::list<_Tp, _Alloc>::_M_insert(iterator, _Args&& ...) [with _Args = {const Option&}; _Tp = Option; _Alloc = std::allocator<Option>]':
#13 34.60 /usr/include/c++/12.2.1/bits/stl_list.h:2003:8: note: parameter passing for argument of type 'std::__cxx11::list<Option>::iterator' changed in GCC 7.1
#13 34.60  2003 |        _M_insert(iterator __position, _Args&&... __args)
#13 34.60       |        ^~~~~~~~~
#13 34.75 cc1plus: all warnings being treated as errors
#13 34.76 make[2]: *** [src/CMakeFiles/vz.dir/build.make:79: src/CMakeFiles/vz.dir/Channel.cpp.o] Error 1
#13 34.76 make[2]: Leaving directory '/vzlogger'
#13 34.76 make[1]: *** [CMakeFiles/Makefile2:921: src/CMakeFiles/vz.dir/all] Error 2
#13 34.76 make[1]: Leaving directory '/vzlogger'
#13 34.76 make: *** [Makefile:169: all] Error 2
------
executor failed running [/bin/sh -c cmake -DBUILD_TEST=off     && make     && make install]: exit code: 2
```

Anyone an idea?

CC. @isarrider 