### PR TITLE
Updated tests for compatibility with Alpine

### DIFF
--- a/tests/MeterD0.cpp
+++ b/tests/MeterD0.cpp
@@ -34,7 +34,7 @@ TEST(MeterD0, basic_dump_fd) {
 
 	std::string dumpName("/tmp/dumpD0UnitTestxyz1234");
 	char tempfilename[L_tmpnam + 1];
-	ASSERT_NE(tmpnam_r(tempfilename), (char *)0);
+	ASSERT_NE(tmpnam(tempfilename), (char *)0);
 	ASSERT_NE(strlen(tempfilename), 0ul);
 	std::list<Option> options;
 	options.push_back(Option("device", tempfilename));
@@ -67,7 +67,7 @@ TEST(MeterD0, basic_dump_fd_autoack) {
 
 	std::string dumpName("/tmp/dumpD0UnitTestxyz1234");
 	char tempfilename[L_tmpnam + 1];
-	ASSERT_NE(tmpnam_r(tempfilename), (char *)0);
+	ASSERT_NE(tmpnam(tempfilename), (char *)0);
 	std::list<Option> options;
 	options.push_back(Option("device", tempfilename));
 	options.push_back(Option("dump_file", (char *)dumpName.c_str()));
@@ -101,7 +101,7 @@ TEST(MeterD0, basic_dump_fd_autoack) {
 
 TEST(MeterD0, HagerEHZ_basic) {
 	char tempfilename[L_tmpnam + 1];
-	ASSERT_NE(tmpnam_r(tempfilename), (char *)0);
+	ASSERT_NE(tmpnam(tempfilename), (char *)0);
 	std::list<Option> options;
 	options.push_back(Option("device", tempfilename));
 	MeterD0 m(options);
@@ -156,7 +156,7 @@ TEST(MeterD0, HagerEHZ_basic) {
 TEST(MeterD0, HagerEHZ_waitsync) {
 	char tempfilename[L_tmpnam + 1];
 	char strend[5] = "end\0";
-	ASSERT_NE(tmpnam_r(tempfilename), (char *)0);
+	ASSERT_NE(tmpnam(tempfilename), (char *)0);
 	std::list<Option> options;
 	options.push_back(Option("device", tempfilename));
 	options.push_back(Option("wait_sync", strend));
@@ -198,7 +198,7 @@ TEST(MeterD0, HagerEHZ_waitsync) {
 TEST(MeterD0, LandisGyr_basic) {
 	char tempfilename[L_tmpnam + 1];
 	char str_pullseq[12] = "2f3f210d0a";
-	ASSERT_NE(tmpnam_r(tempfilename), (char *)0);
+	ASSERT_NE(tmpnam(tempfilename), (char *)0);
 	std::list<Option> options;
 	options.push_back(Option("device", tempfilename));
 	options.push_back(Option("pullseq", str_pullseq));
@@ -295,7 +295,7 @@ int writes_hex(int fd, const char *str) {
 TEST(MeterD0, ACE3000_basic) {
 	char tempfilename[L_tmpnam + 1];
 	char str_pullseq[12] = "2f3f210d0a";
-	ASSERT_NE(tmpnam_r(tempfilename), (char *)0);
+	ASSERT_NE(tmpnam(tempfilename), (char *)0);
 	std::list<Option> options;
 	options.push_back(Option("device", tempfilename));
 	options.push_back(Option("pullseq", str_pullseq));
@@ -406,7 +406,7 @@ baudrate=4, identification=\@DC341TMPBF2ZAK) [Dec 23 11:59:11][d0]   Sending ack
 
 TEST(MeterD0, LuG_E350) {
 	char tempfilename[L_tmpnam + 1];
-	ASSERT_NE(tmpnam_r(tempfilename), (char *)0);
+	ASSERT_NE(tmpnam(tempfilename), (char *)0);
 	std::list<Option> options;
 	options.push_back(Option("device", tempfilename));
 	MeterD0 m(options);

--- a/tests/MeterSML.cpp
+++ b/tests/MeterSML.cpp
@@ -12,7 +12,7 @@ TEST(MeterSML, EMH_basic) {
 	using std::fabs;
 
 	char tempfilename[L_tmpnam + 1];
-	ASSERT_NE(tmpnam_r(tempfilename), (char *)0);
+	ASSERT_NE(tmpnam(tempfilename), (char *)0);
 	std::list<Option> options;
 	options.push_back(Option("device", tempfilename));
 	MeterSML m(options);

--- a/tests/mocks/mock_metermap.cpp
+++ b/tests/mocks/mock_metermap.cpp
@@ -37,6 +37,7 @@ TEST(mock_metermap, basic_open_close_enabled) {
 	o.push_back(Option("protocol", "random"));
 	mock_meter *mtr = new mock_meter(o);
 	mtr->interval(1);
+	testing::Mock::AllowLeak(mtr);
 	EXPECT_CALL(*mtr, isEnabled()).Times(AtLeast(1)).WillRepeatedly(Return(true));
 	{
 		InSequence d;

--- a/tests/ut_MeterExec.cpp
+++ b/tests/ut_MeterExec.cpp
@@ -12,13 +12,13 @@
 // will avoid multiple includes of the same file in a different test case
 // (or linking against the real file from the CMakeLists.txt)
 
-//#include "../src/protocols/MeterExec.cpp"
+// #include "../src/protocols/MeterExec.cpp"
 
 int writes(int fd, const char *str);
 
 TEST(MeterExec, basic) {
 	char tempfilename[L_tmpnam + 1];
-	ASSERT_NE(tmpnam_r(tempfilename), (char *)0);
+	ASSERT_NE(tmpnam(tempfilename), (char *)0);
 	std::list<Option> options;
 	options.push_back(Option("command", tempfilename));
 
@@ -31,7 +31,7 @@ TEST(MeterExec, basic) {
 
 TEST(MeterExec, format1) {
 	char tempfilename[L_tmpnam + 1];
-	ASSERT_NE(tmpnam_r(tempfilename), (char *)0);
+	ASSERT_NE(tmpnam(tempfilename), (char *)0);
 	std::list<Option> options;
 	options.push_back(Option("command", tempfilename));
 	options.push_back(Option("format", (char *)"$v"));
@@ -43,7 +43,7 @@ TEST(MeterExec, format1) {
 
 TEST(MeterExec, format2) {
 	char tempfilename[L_tmpnam + 1];
-	ASSERT_NE(tmpnam_r(tempfilename), (char *)0);
+	ASSERT_NE(tmpnam(tempfilename), (char *)0);
 	std::list<Option> options;
 	options.push_back(Option("command", tempfilename));
 	options.push_back(Option("format", (char *)"$i : $v"));
@@ -55,7 +55,7 @@ TEST(MeterExec, format2) {
 
 TEST(MeterExec, format3) {
 	char tempfilename[L_tmpnam + 1];
-	ASSERT_NE(tmpnam_r(tempfilename), (char *)0);
+	ASSERT_NE(tmpnam(tempfilename), (char *)0);
 	std::list<Option> options;
 	options.push_back(Option("command", tempfilename));
 	options.push_back(Option("format", (char *)"$t;$i : $v"));

--- a/tests/ut_MeterFile.cpp
+++ b/tests/ut_MeterFile.cpp
@@ -12,13 +12,13 @@
 // will avoid multiple includes of the same file in a different test case
 // (or linking against the real file from the CMakeLists.txt)
 
-//#include "../src/protocols/MeterFile.cpp"
+// #include "../src/protocols/MeterFile.cpp"
 
 int writes(int fd, const char *str);
 
 TEST(MeterFile, basic) {
 	char tempfilename[L_tmpnam + 1];
-	ASSERT_NE(tmpnam_r(tempfilename), (char *)0);
+	ASSERT_NE(tmpnam(tempfilename), (char *)0);
 	std::list<Option> options;
 	options.push_back(Option("path", tempfilename));
 	options.push_back(Option("interval", 1));
@@ -66,7 +66,7 @@ TEST(MeterFile, basic) {
 
 TEST(MeterFile, format1) {
 	char tempfilename[L_tmpnam + 1];
-	ASSERT_NE(tmpnam_r(tempfilename), (char *)0);
+	ASSERT_NE(tmpnam(tempfilename), (char *)0);
 	std::list<Option> options;
 	options.push_back(Option("path", tempfilename));
 	options.push_back(Option("format", (char *)"$v"));
@@ -112,7 +112,7 @@ TEST(MeterFile, format1) {
 
 TEST(MeterFile, format2) {
 	char tempfilename[L_tmpnam + 1];
-	ASSERT_NE(tmpnam_r(tempfilename), (char *)0);
+	ASSERT_NE(tmpnam(tempfilename), (char *)0);
 	std::list<Option> options;
 	options.push_back(Option("path", tempfilename));
 	options.push_back(Option("format", (char *)"$i : $v"));
@@ -173,7 +173,7 @@ TEST(MeterFile, reading_times) {
 
 TEST(MeterFile, format3) {
 	char tempfilename[L_tmpnam + 1];
-	ASSERT_NE(tmpnam_r(tempfilename), (char *)0);
+	ASSERT_NE(tmpnam(tempfilename), (char *)0);
 	std::list<Option> options;
 	options.push_back(Option("path", tempfilename));
 	options.push_back(Option("format", (char *)"$t;$i : $v"));


### PR DESCRIPTION
tmpnam_r is not avialble on muslc (which is used in Alpine). btw: both tmpnam and tmpnam_r are considered to be bad, the proper fix would be to rewrite the tests.

AllowLeak is needed because there seems to be slightly different behavior in pointer cleanup. Of course, this could also be fixed properly.