### PR TITLE
Cleanup for the debian package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -289,11 +289,6 @@ if( ENABLE_LOCAL AND NOT MICROHTTPD_FOUND )
 Install microhttpd or call cmake -DMICROHTTPD_HOME=path_to_microhttpd_install")
 endif( ENABLE_LOCAL AND NOT MICROHTTPD_FOUND )
 
-# add some files to the installation target
-INSTALL(FILES README.md COPYING DESTINATION
-  share/doc/vzlogger-${VZLOGGER_MAJOR_VERSION}-${VZLOGGER_MINOR_VERSION}
-)
-
 # add clean-all target that removes the cached files from cmake as well (see e.g. issue #186)
 add_custom_target(clean-all
     COMMAND ${CMAKE_BUILD_TOOL} clean

--- a/debian/changelog
+++ b/debian/changelog
@@ -2,7 +2,7 @@ vzlogger (0.8.1) unstable; urgency=low
  
   * Latest version
 
- -- Justin Otherguy (signing key for debian packages only) <justin@justinotherguy.org>  Sat, 21 Jan 2023 13:18:03 +0100
+ -- Joachim Zobel <jz-2017@heute-morgen.de>  Sat, 21 Jan 2023 19:52:01 +0100
 
 vzlogger (0.3.5) stable; urgency=low
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,8 +1,15 @@
+vzlogger (0.8.1) unstable; urgency=low
+ 
+  * Latest version
+
+ -- Justin Otherguy (signing key for debian packages only) <justin@justinotherguy.org>  Sat, 21 Jan 2023 13:18:03 +0100
+
 vzlogger (0.3.5) stable; urgency=low
 
   * including changes kindly contributed by Peter Evertz (initiation sequence for some meters)
 
  -- Justin Otherguy (signing key for debian packages only) <justin@justinotherguy.org>  Tue, 08 Oct 2013 21:28:01 +0200
+
 vzlogger (0.3.4-rc1) stable; urgency=low
   
   * updated version to reflect changes in CMakeLists.txt

--- a/debian/control
+++ b/debian/control
@@ -1,9 +1,13 @@
 Source: vzlogger
 Section: net
 Priority: optional
-Maintainer: Steffen Vogel <info@steffenvogel.de>
-Build-Depends: debhelper (>= 7.0.50~), pkg-config (>= 0.25), libjson-c-dev (>= 0.9), libcurl4-openssl-dev (>= 7.19), libmicrohttpd-dev (>= 0.4.6), libsml-dev (>= 0.1.1), cmake, libsasl2-dev, libssl-dev, libgcrypt-dev, libgnutls28-dev, uuid-dev, libunistring-dev, git
-Standards-Version: 3.9.1
+Maintainer: Joachim Zobel <jz-2017@heute-morgen.de>
+Build-Depends: debhelper (>= 13), pkg-config (>= 0.25), 
+ libjson-c-dev (>= 0.9), libcurl4-openssl-dev (>= 7.19),
+ libmicrohttpd-dev (>= 0.4.6), libsml-dev (>= 0.1.1), cmake, libsasl2-dev,
+ libssl-dev, libgcrypt-dev, libgnutls28-dev, uuid-dev, libunistring-dev,
+ libgmock-dev, libgtest-dev, pandoc
+Standards-Version: 4.6.1
 Homepage: http://wiki.volkszaehler.org/software/controller/vzlogger
 Vcs-Git: git://github.com/volkszaehler/volkszaehler.org.git
 Vcs-Browser: http://github.com/volkszaehler/volkszaehler.org/tree/master/misc/controller/vzlogger/

--- a/debian/copyright
+++ b/debian/copyright
@@ -6,9 +6,9 @@ Files: *
 Copyright: Copyright 2011 Steffen Vogel <info@steffenvogel.de>
  Copyright (C) 2009 by Tobias Mueller
  Copyright (c) 2011, DAI-Labor, TU-Berlin
- Copyright (c) 2015, 2018 Matthias Behr
- Copyright (c) 2011 - 2017, The volkszaehler.org project
  Copyright 2011 Fraunhofer ITWM
+ Copyright (c) 2015, 2018 Matthias Behr
+ Copyright (c) 2011 - 2023, The volkszaehler.org project
 License: GPL-3
 
 Files: debian/*

--- a/debian/copyright
+++ b/debian/copyright
@@ -4,6 +4,10 @@ Source: https://github.com/narc-Ontakac2/vzlogger.git
 
 Files: *
 Copyright: Copyright 2011 Steffen Vogel <info@steffenvogel.de>
+ Copyright (C) 2009 by Tobias Mueller
+ Copyright (c) 2011, DAI-Labor, TU-Berlin
+ Copyright (c) 2015, 2018 Matthias Behr
+ Copyright (c) 2011 - 2017, The volkszaehler.org project
  Copyright 2011 Fraunhofer ITWM
 License: GPL-3
 

--- a/debian/copyright
+++ b/debian/copyright
@@ -1,32 +1,32 @@
-This work was packaged for Debian by:
-    Steffen Vogel <info@steffenvogel.de> on Thu, 09 Jun 2011 16:04:25 +0200
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: vzlogger
+Source: https://github.com/narc-Ontakac2/vzlogger.git
 
-It was downloaded from:
-    http://volkszaehler.org
+Files: *
+Copyright: Copyright 2011 Steffen Vogel <info@steffenvogel.de>
+ Copyright 2011 Fraunhofer ITWM
+License: GPL-3
 
-Upstream Author(s):
-    Steffen Vogel <info@steffenvogel.de>
+Files: debian/*
+Copyright: Copyright 2011 Steffen Vogel <info@steffenvogel.de>
+ Copyright 2023 Joachim Zobel <jz-2017@heute-morgen.de>
+License: GPL-3
 
-Copyright:
-    Copyright (C) 2011 Steffen Vogel
+License: GPL-3
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+ .
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ .
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ .
+ On Debian systems, the full text of the GNU General Public
+ License version 3 can be found in the file
+ `/usr/share/common-licenses/GPL-3'.
 
-License:
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
-
-    This package is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
-
-    You should have received a copy of the GNU General Public License
-    along with this program. If not, see <http://www.gnu.org/licenses/>.
-
-On Debian systems, the complete text of the GNU General
-Public License version 3 can be found in "/usr/share/common-licenses/GPL-3".
-
-The Debian packaging is:
-    Copyright (C) 2011 Steffen Vogel <info@steffenvogel.de>
-    and is licensed under the GPL version 3, see above.

--- a/debian/rules
+++ b/debian/rules
@@ -9,5 +9,20 @@
 # Uncomment this to turn on verbose mode.
 #export DH_VERBOSE=1
 
+ifneq (,$(filter nocheck,$(DEB_BUILD_OPTIONS)))
+override_dh_auto_configure:
+	dh_auto_configure -- -DBUILD_TEST=off
+endif
+
+ifneq (,$(filter nocheck,$(DEB_BUILD_OPTIONS)))
+override_dh_auto_test: ;
+endif
+
+execute_after_dh_auto_build:
+	pandoc -o vzlogger.1 -s -t man debian/vzlogger.1.md
+
+execute_after_dh_clean:
+	rm vzlogger.1
+
 %:
 	dh $@ 

--- a/debian/rules
+++ b/debian/rules
@@ -22,7 +22,7 @@ execute_after_dh_auto_build:
 	pandoc -o vzlogger.1 -s -t man debian/vzlogger.1.md
 
 execute_after_dh_clean:
-	rm vzlogger.1
+	rm -f vzlogger.1
 
 %:
 	dh $@ 

--- a/debian/source/lintian-overrides
+++ b/debian/source/lintian-overrides
@@ -1,0 +1,2 @@
+# May be odd, but I don't want to change the (non debian) past
+odd-historical-debian-changelog-version *0.3.4-rc1*

--- a/debian/vzlogger.1.md
+++ b/debian/vzlogger.1.md
@@ -1,0 +1,53 @@
+# NAME
+
+vzlogger -- A tool to read and log measurements of a wide variety of smart meters and sensors 
+
+# SYNOPSIS
+
+**vzlogger** [**-c** *conf*] [**-o** *log*] [**-f**] [**-l**] [**-p** *port*] [**-r**] [**-v**] [**-h**] [**-V**]
+
+
+# DESCRIPTION
+
+This is the man page for the vzlogger program. It briefly documents
+the parameters. The main documentation is available online. A list 
+of supported protocols can be obtained with the -h option.
+
+
+**-c, --config** **<file>**
+:     This option sets the configuration file to read from. The default is
+**/etc/vzlogger.conf**. Note that command line options override configuration
+file entries.
+
+**-o, --log** **<file>**
+:     This options sets the file to log output to. 
+
+**-f, --foreground**
+:     This prevents detaching from the terminal and lets the program run
+in the foreground.
+
+**-l, --httpd**
+:     This activates a local interface tiny HTTPd which serves live readings.
+
+**-p, --httpd-port**
+:     This sets the TCP port the HTTPd is listening on.
+
+**-r, --register**
+:     This registers a device.
+
+**-v, --verbose**
+:     This enables verbose output.
+
+**-h, --help**
+:     This shows the help.
+
+**-V, --version**
+:     This shows the version of vzlogger.
+
+
+# COPYRIGHT
+The vzlogger program is Copyright (C) by Steffen Vogel <stv0g@0l.de> and others.
+
+# SEE ALSO
+[vzlogger.conf parameters](https://wiki.volkszaehler.org/software/controller/vzlogger/vzlogger_conf_parameter?s[]=vzlogger&s[]=conf)
+

--- a/debian/vzlogger.docs
+++ b/debian/vzlogger.docs
@@ -1,0 +1,1 @@
+README*.md

--- a/debian/vzlogger.manpages
+++ b/debian/vzlogger.manpages
@@ -1,0 +1,1 @@
+vzlogger.1

--- a/debian/vzlogger.postinst
+++ b/debian/vzlogger.postinst
@@ -3,7 +3,7 @@
 case "$1" in
     configure)
 	if ! id vzlogger > /dev/null 2>&1 ; then
-	    adduser --system --no-create-home \
+	    adduser --system --no-create-home --home /nonexistent \
 		--group --disabled-password --shell /bin/false \
 		vzlogger
             usermod -a -G dialout vzlogger

--- a/debian/vzlogger.service
+++ b/debian/vzlogger.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=vzlogger
-After=syslog.target network.target ntp.service
+After=network.target ntp.service
 
 [Service]
 ExecStart=/usr/bin/vzlogger -c /etc/vzlogger.conf


### PR DESCRIPTION
This silences all lintian warnings
.
The change moves the installation of the documentation from CMake to debuild. This has two advantages:
1. The files are automatically put into the correct debian place without explicitly naming it.
2. I know debuild while I would have to learn cmake.

The second reason is of course questionable :-) I am also unsure about what is considered a supported target platform. So please comment if this is a reasonable approach.

The change also adds a man page (which is a debian requirement). 
