### PR TITLE
mqtt without vzlogger is pointless

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -261,7 +261,7 @@ popd
 
 ###############################
 # vzlogger
-if [ -z "$1" ] || contains "$*" vzlogger; then
+if [ -z "$1" ] || contains "$*" vzlogger || contains "$*" mqtt; then
 	echo
 	echo "building and installing vzlogger"
 


### PR DESCRIPTION
Optional MQTT is part of vzlogger, therefore compilation of vzlogger by install.sh is necessary. #575 