### PR TITLE
WIP: [MeterSML] delay generation of Readings

### DIFF
--- a/.github/workflows/build+test.yml
+++ b/.github/workflows/build+test.yml
@@ -11,4 +11,4 @@ jobs:
     - uses: actions/checkout@v2
     - run: cmake . -DSML_HOME=../libsml/sml
     - run: make
-    - run: ctest
+    - run: ctest || ctest --rerun-failed --output-on-failure

--- a/include/protocols/MeterSML.hpp
+++ b/include/protocols/MeterSML.hpp
@@ -84,7 +84,7 @@ class MeterSML : public vz::protocol::Protocol {
 	 * @param rd the reading to store to
 	 * @return true if it is a valid entry
 	 */
-	bool _parse(sml_list *list, Reading *rd);
+	bool _parse(sml_list *entry, double *value, ReadingIdentifier **rid, timeval *tv);
 
 	/**
 	 * Open serial port by device


### PR DESCRIPTION
something like this is required for various situations where we want to manipulate the readings from the telegram before submitting them to vzlogger core.
applies to #431 #476 #570.
also related to #490 .