### PR TITLE
Changed service to run as already existing vzlogger user

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+vzlogger (0.8.2) unstable; urgency=medium
+
+  * Fixed service running as root 
+
+ -- Joachim Zobel <jz-2017@heute-morgen.de>  Sat, 20 May 2023 14:01:01 +0200
+
 vzlogger (0.8.1) unstable; urgency=low
  
   * Latest version

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: vzlogger
 Section: net
 Priority: optional
 Maintainer: Joachim Zobel <jz-2017@heute-morgen.de>
-Build-Depends: debhelper (>= 13), pkg-config (>= 0.25), 
+Build-Depends: debhelper (>= 12), pkg-config (>= 0.25), 
  libjson-c-dev (>= 0.9), libcurl4-openssl-dev (>= 7.19),
  libmicrohttpd-dev (>= 0.4.6), libsml-dev (>= 0.1.1), cmake, libsasl2-dev,
  libssl-dev, libgcrypt-dev, libgnutls28-dev, uuid-dev, libunistring-dev,

--- a/debian/vzlogger.service
+++ b/debian/vzlogger.service
@@ -4,6 +4,8 @@ After=network.target ntp.service
 
 [Service]
 ExecStart=/usr/bin/vzlogger -c /etc/vzlogger.conf
+User=vzlogger
+Group=vzlogger
 ExecReload=
 StandardOutput=null
 


### PR DESCRIPTION
It looks like it has been forgotten to configure the vzlogger user when switching to systemd. Luckily everything is talready there. The user exists and belongs to the dialout goup. The logfile is owned by the vzlogger user.

Since this change is a troublemaker I want my vzlogger to make one logrotation after applying it, so **do not merge** it yet.