### PR TITLE
Update vzlogger.service

### DIFF
--- a/etc/vzlogger.service
+++ b/etc/vzlogger.service
@@ -3,6 +3,7 @@ Description=vzlogger
 After=syslog.target network.target ntp.service
 
 [Service]
+ExecStart=
 ExecStart=/usr/local/bin/vzlogger -c /etc/vzlogger.conf
 ExecReload=
 StandardOutput=null


### PR DESCRIPTION
When runing Vzlogger especial not as root many Systemd have some problems with execStart  --> systemd: vzlogger.service has more than one ExecStart= setting

by make one clean ExecStart= , problem gone