### PR TITLE
Added support for 5 Channel S0 USB Pulse meter (original: 5-kanaals S0 Pulse Meter op USB)

### DIFF
--- a/etc/vzlogger.conf.sos_s0_reader
+++ b/etc/vzlogger.conf.sos_s0_reader
@@ -1,0 +1,101 @@
+/**
+ * vzlogger configuration
+ *
+ * Use properly encoded JSON with javascript comments
+ *
+ * Take a look at the wiki for detailed information:
+ * http://wiki.volkszaehler.org/software/controller/vzlogger#configuration
+ *
+ * For an online configuration editor refer to:
+ * http://volkszaehler.github.io/vzlogger/
+ */
+
+{
+    // General settings
+    "verbosity": 10,         // log verbosity (0=log_alert, 1=log_error, 3=log_warning, 5=log_info, 10=log_debug, 15=log_finest)
+    "log": "/var/log/vzlogger.log", // log file, optional
+    "retry": 30,            // http retry delay in seconds
+
+    // Build-in HTTP server
+    "local": {
+        "enabled": false,   // enable local HTTPd for serving live readings
+        "port": 8080,       // TCP port for local HTTPd
+        "index": true,      // provide index listing of available channels if no UUID was requested
+        "timeout": 30,      // timeout for long polling comet requests in seconds (0 disables comet)
+        "buffer": -1        // HTTPd buffer configuration for serving readings, default -1
+                            //   >0: number of seconds of readings to serve
+                            //   <0: number of tuples to server per channel (e.g. -3 will serve 3 tuples)
+    },
+
+    // realtime notification settings
+    //"push": [
+    //    {
+    //        "url": "http://127.0.0.1:5582"  // notification destination, e.g. frontend push-server
+    //    }
+    //],
+
+    // mqtt client support (if ENABLE_MQTT set at cmake generation)
+    "mqtt": {
+        "enabled": false,  // enable mqtt client. needs host and port as well
+        "host": "test.mosquitto.org", // mqtt server addr
+        "port": 1883, // 1883 for unencrypted, 8883 enc, 8884 enc cert needed,
+        "cafile": "", // optional file with server CA
+        "capath": "", // optional path for server CAs. see mosquitto.conf. Specify only cafile or capath
+        "certfile": "", // optional file for your client certificate (e.g. client.crt)
+        "keyfile": "", // optional path for your client certficate private key (e.g. client.key)
+        "keypass": "", // optional password for your private key
+        "keepalive": 30, // optional keepalive in seconds.
+        "topic": "vzlogger/data", // optional topic dont use $ at start and no / at end
+        "id": "", // optional static id, if not set "vzlogger_<pid>" will be used
+        "user": "", // optional user name for the mqtt server
+        "pass": "", // optional password for the mqtt server
+        "retain": false, // optional use retain message flag
+        "rawAndAgg": false, // optional publish raw values even if agg mode is used
+        "qos": 0, // optional quality of service, default is 0
+        "timestamp": false // optional whether to include a timestamp in the payload
+    },
+
+    // Meter configuration
+    "meters": [
+        {
+            // Example SOS S0 meter
+
+            "enabled": true,                // disabled meters will be ignored (default)
+            "allowskip": false,             // errors when opening meter may be ignored if enabled
+            "protocol": "sos_s0",           // meter protocol, see 'vzlogger -h' for full list
+            "device": "/dev/ttyACM0",       // meter device
+
+//          "aggtime": 20,                  // aggregate meter readings and send middleware update after <aggtime> seconds
+            "interval": 0,                  // Wartezeit in Sekunden bis neue Werte in die middleware übertragen werden
+
+            "channels": [{
+                "uuid": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeee",
+                "identifier": "M1",         // S0 Port identifier
+                "api": "null",
+                "aggmode": "SUM"            // aggregation mode: aggregate meter readings during <aggtime> interval
+            }, {
+                "uuid": "aaaaaaaa-bbbb-cccc-dddd-ffffffff",
+                "identifier": "M2",         // S0 Port identifier
+                "api": "null",
+                "aggmode": "SUM"            // aggregation mode: aggregate meter readings during <aggtime> interval
+            }, {
+                "uuid": "aaaaaaaa-bbbb-cccc-dddd-11111111",
+                "identifier": "M3",         // S0 Port identifier
+                "api": "null",
+                "aggmode": "SUM"            // aggregation mode: aggregate meter readings during <aggtime> interval
+            }, {
+                "uuid": "aaaaaaaa-bbbb-cccc-dddd-22222222",
+                "identifier": "M4",         // S0 Port identifier
+                "api": "null",
+                "aggmode": "SUM"            // aggregation mode: aggregate meter readings during <aggtime> interval
+            }, {
+                "uuid": "aaaaaaaa-bbbb-cccc-dddd-33333333",
+                "identifier": "M5",         // S0 Port identifier
+                "api": "null",
+                "aggmode": "SUM"            // aggregation mode: aggregate meter readings during <aggtime> interval
+            }
+            ]
+        }
+    ]
+}
+

--- a/etc/vzlogger.conf.sos_s0_reader
+++ b/etc/vzlogger.conf.sos_s0_reader
@@ -66,7 +66,8 @@
             "device": "/dev/ttyACM0",       // meter device
 
 //          "aggtime": 20,                  // aggregate meter readings and send middleware update after <aggtime> seconds
-            "interval": 0,                  // Wartezeit in Sekunden bis neue Werte in die middleware übertragen werden
+            "interval": -1,                  // wait time in seconds until new values will transmitted to middleware 
+//          "send_zero": false,             
 
             "channels": [{
                 "uuid": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeee",

--- a/etc/vzlogger_generic.schema.json
+++ b/etc/vzlogger_generic.schema.json
@@ -963,7 +963,35 @@
                 "required": ["protocol"]
             }]
         },
-
+        "meterSOS_S0": {
+            "title": "SOS S0 Pulse meter devices",
+            "allOf": [{
+                "$ref": "#/definitions/meter"
+            }, {
+                "properties": {
+                    "protocol": {
+                        "type": "string",
+                        "enum": ["sos_s0"],
+                        "default": "sos_s0"
+                    },
+                    "device": {
+                        "type": "string",
+                        "description": "UART device the device is connected to. E.g. /dev/ttyACM0"
+                    },
+                    "read_timeout": {
+                        "type": "integer",
+                        "default": 10,
+                        "description": "Read timeout in secs. Data readout is considered finished if no state change after that timeout."
+                    },
+                    "send_zero": {
+                        "type": "boolean",
+                        "default": false,
+                        "description": "If active/true send data once a second even if no impulses have been received. Use aggregation is this case to reduce frequency."
+                    }
+                },
+                "required": ["protocol", "device"]
+            }]
+        },
         "channels": {
             "type": "array",
             "items": {
@@ -1009,6 +1037,8 @@
                         "$ref": "#/definitions/meterOMS"
                     }, {
                         "$ref": "#/definitions/meterW1therm"
+                    }, {
+                        "$ref": "#/definitions/meterSOS_S0"
                     }
 
                 ]

--- a/include/meter_protocol.hpp
+++ b/include/meter_protocol.hpp
@@ -38,5 +38,6 @@ typedef enum meter_procotol {
 	meter_protocol_ocr,
 	meter_protocol_w1therm,
 	meter_protocol_oms,
+	meter_protocol_sos_s0,
 } meter_protocol_t;
 #endif /* _meter_protocol_hpp_ */

--- a/include/protocols/MeterSOS_S0.hpp
+++ b/include/protocols/MeterSOS_S0.hpp
@@ -59,6 +59,7 @@ class MeterSOS_S0 : public vz::protocol::Protocol {
 	int _baudrate;
 	parity_type_t _parity;
     size_t _read_timeout_s;
+    bool _send_zero;
 
 	int _fd; /* file descriptor of port */
 	struct termios _oldtio; /* required to reset port */

--- a/include/protocols/MeterSOS_S0.hpp
+++ b/include/protocols/MeterSOS_S0.hpp
@@ -1,0 +1,70 @@
+/**
+ * Plaintext protocol of S0 Pulse meter devices 
+ *  --> https://www.sossolutions.nl/5-kanaals-s0-pulse-meter-op-usb
+ *
+ * The device is a USB s0 logger device.
+ * 
+ * The protocol is defined as follows: 
+ *       ‘ID:x:I:y:M1:a:b:M2:c:d:M3:e:f:M4:g:h:M5:i:j’’
+ *        - x = ID des S0 pulse meter (unique)
+ * 	      - y = number of seconds since last message (default: 10 second)
+ *        - a,c,e,g,i = number of pulses since last message
+ *        - b,d,f,h,j = total number of pulses since start of device
+ *
+ * @package vzlogger
+ * @copyright Copyright (c) 2011 - 2023, The volkszaehler.org project
+ * @license http://www.gnu.org/licenses/gpl.txt GNU Public License
+ * @author Hans-Joerg Leu <info@steffenvogel.de>
+ */
+/*
+ * This file is part of volkzaehler.org
+ *
+ * volkzaehler.org is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * volkzaehler.org is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with volkszaehler.org. If not, see <http://www.gnu.org/licenses/>.
+ */
+// RW: added ack
+#ifndef _SOS_S0_H_
+#define _SOS_S0_H_
+
+#include <termios.h>
+#include <protocols/Protocol.hpp>
+
+class MeterSOS_S0 : public vz::protocol::Protocol {
+  public:
+	MeterSOS_S0(std::list<Option> &options);
+	virtual ~MeterSOS_S0();
+
+	int open();
+	int close();
+	ssize_t read(std::vector<Reading> &rds, size_t n);
+	virtual bool allowInterval() const {
+		return false;
+	} // only allow conf setting interval if pull is set (otherwise meter sends autom.)
+
+	const char *device() const { return _device.c_str(); }
+
+  private:
+	std::string _device;
+	std::string _dump_file;
+	int _baudrate;
+	parity_type_t _parity;
+    size_t _read_timeout_s;
+
+	int _fd; /* file descriptor of port */
+	struct termios _oldtio; /* required to reset port */
+
+	int _openDevice(struct termios *old_tio, speed_t baudrate);
+    bool _is_valid_fd();
+};
+
+#endif /* _D0_H_ */

--- a/include/protocols/MeterSOS_S0.hpp
+++ b/include/protocols/MeterSOS_S0.hpp
@@ -1,10 +1,10 @@
 /**
- * Plaintext protocol of S0 Pulse meter devices 
+ * Plaintext protocol of S0 Pulse meter devices
  *  --> https://www.sossolutions.nl/5-kanaals-s0-pulse-meter-op-usb
  *
  * The device is a USB s0 logger device.
- * 
- * The protocol is defined as follows: 
+ *
+ * The protocol is defined as follows:
  *       ‘ID:x:I:y:M1:a:b:M2:c:d:M3:e:f:M4:g:h:M5:i:j’’
  *        - x = ID des S0 pulse meter (unique)
  * 	      - y = number of seconds since last message (default: 10 second)
@@ -36,8 +36,8 @@
 #ifndef _SOS_S0_H_
 #define _SOS_S0_H_
 
-#include <termios.h>
 #include <protocols/Protocol.hpp>
+#include <termios.h>
 
 class MeterSOS_S0 : public vz::protocol::Protocol {
   public:
@@ -58,14 +58,14 @@ class MeterSOS_S0 : public vz::protocol::Protocol {
 	std::string _dump_file;
 	int _baudrate;
 	parity_type_t _parity;
-    size_t _read_timeout_s;
-    bool _send_zero;
+	size_t _read_timeout_s;
+	bool _send_zero;
 
-	int _fd; /* file descriptor of port */
+	int _fd;                /* file descriptor of port */
 	struct termios _oldtio; /* required to reset port */
 
 	int _openDevice(struct termios *old_tio, speed_t baudrate);
-    bool _is_valid_fd();
+	bool _is_valid_fd();
 };
 
 #endif /* _D0_H_ */

--- a/include/protocols/MeterSOS_S0.hpp
+++ b/include/protocols/MeterSOS_S0.hpp
@@ -8,6 +8,7 @@
  *       ‘ID:x:I:y:M1:a:b:M2:c:d:M3:e:f:M4:g:h:M5:i:j’’
  *        - x = ID des S0 pulse meter (unique)
  * 	      - y = number of seconds since last message (default: 10 second)
+ *        - M1,M2,M3,M4,M5 = identifier name for corresponding S0 port on device
  *        - a,c,e,g,i = number of pulses since last message
  *        - b,d,f,h,j = total number of pulses since start of device
  *

--- a/include/protocols/MeterSOS_S0.hpp
+++ b/include/protocols/MeterSOS_S0.hpp
@@ -1,0 +1,70 @@
+/**
+ * Plaintext protocol of S0 Pulse meter devices 
+ *  --> https://www.sossolutions.nl/5-kanaals-s0-pulse-meter-op-usb
+ *
+ * The device is a USB s0 logger device.
+ * 
+ * The protocol is defined as follows: 
+ *       ‘ID:x:I:y:M1:a:b:M2:c:d:M3:e:f:M4:g:h:M5:i:j’’
+ *        - x = ID des S0 pulse meter (unique)
+ * 	      - y = number of seconds since last message (default: 10 second)
+ *        - a,c,e,g,i = number of pulses since last message
+ *        - b,d,f,h,j = total number of pulses since start of device
+ *
+ * @package vzlogger
+ * @copyright Copyright (c) 2011 - 2023, The volkszaehler.org project
+ * @license http://www.gnu.org/licenses/gpl.txt GNU Public License
+ * @author Lurchi70 <https://github.com/Lurchi70/vzlogger>
+ */
+/*
+ * This file is part of volkzaehler.org
+ *
+ * volkzaehler.org is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * volkzaehler.org is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with volkszaehler.org. If not, see <http://www.gnu.org/licenses/>.
+ */
+// RW: added ack
+#ifndef _SOS_S0_H_
+#define _SOS_S0_H_
+
+#include <termios.h>
+#include <protocols/Protocol.hpp>
+
+class MeterSOS_S0 : public vz::protocol::Protocol {
+  public:
+	MeterSOS_S0(std::list<Option> &options);
+	virtual ~MeterSOS_S0();
+
+	int open();
+	int close();
+	ssize_t read(std::vector<Reading> &rds, size_t n);
+	virtual bool allowInterval() const {
+		return false;
+	} // only allow conf setting interval if pull is set (otherwise meter sends autom.)
+
+	const char *device() const { return _device.c_str(); }
+
+  private:
+	std::string _device;
+	std::string _dump_file;
+	int _baudrate;
+	parity_type_t _parity;
+    size_t _read_timeout_s;
+
+	int _fd; /* file descriptor of port */
+	struct termios _oldtio; /* required to reset port */
+
+	int _openDevice(struct termios *old_tio, speed_t baudrate);
+    bool _is_valid_fd();
+};
+
+#endif /* _D0_H_ */

--- a/src/Meter.cpp
+++ b/src/Meter.cpp
@@ -36,6 +36,7 @@
 #include <protocols/MeterFluksoV2.hpp>
 #include <protocols/MeterRandom.hpp>
 #include <protocols/MeterS0.hpp>
+#include <protocols/MeterSOS_S0.hpp>
 #ifdef SML_SUPPORT
 #include <protocols/MeterSML.hpp>
 #endif
@@ -61,6 +62,7 @@ static const meter_details_t protocols[] = {
 	METER_DETAIL(fluksov2, Fluksov2, "Read from Flukso's onboard SPI fifo", 16),
 	METER_DETAIL(s0, S0, "S0-meter directly connected to RS232", 4),
 	METER_DETAIL(d0, D0, "DLMS/IEC 62056-21 plaintext protocol", 400),
+	METER_DETAIL(sos_s0, SOS_S0, "SOS S0 Pulse Meter via USB", 5),
 #ifdef SML_SUPPORT
 	METER_DETAIL(sml, Sml, "Smart Message Language as used by EDL-21, eHz and SyM²", 32),
 #endif // SML_SUPPORT
@@ -187,6 +189,10 @@ Meter::Meter(std::list<Option> pOptions) : _name("meter") {
 		_identifier = ReadingIdentifier::Ptr(new ObisIdentifier());
 		break;
 #endif
+	case meter_protocol_sos_s0:
+		_protocol = vz::protocol::Protocol::Ptr(new MeterSOS_S0(pOptions));
+		_identifier = ReadingIdentifier::Ptr(new StringIdentifier());
+		break;
 	default:
 		break;
 	}

--- a/src/Reading.cpp
+++ b/src/Reading.cpp
@@ -103,6 +103,7 @@ ReadingIdentifier::Ptr reading_id_parse(meter_protocol_t protocol, const char *s
 	case meter_protocol_file:
 	case meter_protocol_exec:
 	case meter_protocol_s0:
+	case meter_protocol_sos_s0:
 	case meter_protocol_ocr:
 	case meter_protocol_w1therm:
 		rid = ReadingIdentifier::Ptr(new StringIdentifier(string));

--- a/src/protocols/CMakeLists.txt
+++ b/src/protocols/CMakeLists.txt
@@ -27,6 +27,7 @@ endif( OMS_SUPPORT )
 set(proto_srcs
   MeterS0.cpp ../../include/protocols/MeterS0.hpp
   MeterD0.cpp ../../include/protocols/MeterD0.hpp
+  MeterSOS_S0.cpp ../../include/protocols/MeterSOS_S0.hpp
   ${sml_srcs}
   MeterFluksoV2.cpp
   ${ocr_srcs}

--- a/src/protocols/MeterSOS_S0.cpp
+++ b/src/protocols/MeterSOS_S0.cpp
@@ -1,0 +1,296 @@
+/**
+ * Plaintext protocol according to DIN EN 62056-21
+ *
+ * This protocol uses OBIS codes to identify the readout data
+ *
+ * This is our example protocol. Use this skeleton to add your own
+ * protocols and meters.
+ *
+ * @package vzlogger
+ * @copyright Copyright (c) 2011 - 2023, The volkszaehler.org project
+ * @license http://www.gnu.org/licenses/gpl.txt GNU Public License
+ * @author Lurchi70 <https://github.com/Lurchi70/vzlogger>
+ */
+/*
+ * This file is part of volkzaehler.org
+ *
+ * volkzaehler.org is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * volkzaehler.org is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with volkszaehler.org. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <ctype.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/time.h>
+#include <time.h>
+#include <unistd.h>
+
+#include "threads.h"
+
+#include "protocols/MeterSOS_S0.hpp"
+#include <VZException.hpp>
+
+#include <string>
+#include <sstream>
+#include <vector>
+
+
+namespace MeterSOS_S0_Helper {
+
+bool hasEnding (const std::string &fullString, const std::string &ending) {
+    if (fullString.length() >= ending.length()) {
+        return (0 == fullString.compare (fullString.length() - ending.length(), ending.length(), ending));
+    } 
+
+    return false;
+}
+
+void tokenize(const std::string &text, const std::string &delimiter, std::vector<std::string> &data){
+    size_t start = text.find_first_not_of(delimiter);
+    size_t end = start;
+
+    while (start != std::string::npos){
+        end = text.find(delimiter, start);
+        data.push_back(text.substr(start, end-start));
+        start = text.find_first_not_of(delimiter, end);
+    }
+}
+
+};
+
+MeterSOS_S0::MeterSOS_S0(std::list<Option> &options)
+	: Protocol("sos_s0"), _device(""), _read_timeout_s(10) {
+	OptionList option_list;
+
+	// connection
+	try {
+		_device = option_list.lookup_string(options, "device");
+		if (!_device.length()) {
+			throw vz::VZException("device without length");
+		}
+	} catch (vz::VZException &e) {
+		print(log_alert, "Missing device or host", name().c_str());
+		throw;
+	}
+
+	// baudrate and parity are hard coded for this devices
+    _baudrate = B9600;
+	_parity = parity_7n1;
+
+	try {
+		_read_timeout_s = option_list.lookup_int(options, "read_timeout");
+	} catch (vz::OptionNotFoundException &e) {
+		// use default: 10s from constructor
+	} catch (vz::VZException &e) {
+		print(log_alert, "Failed to parse read_timeout", name().c_str());
+		throw;
+	}
+}
+
+MeterSOS_S0::~MeterSOS_S0() {
+}
+
+int MeterSOS_S0::open() {
+
+	if (_device.length() > 0) {
+		_fd = _openDevice(&_oldtio, _baudrate);
+	} 
+
+	return (_fd < 0) ? ERR : SUCCESS;
+}
+
+int MeterSOS_S0::close() {
+	return ::close(_fd);
+}
+
+ssize_t MeterSOS_S0::read(std::vector<Reading> &rds, size_t max_readings) {
+
+    time_t start_time(0);
+    time_t end_time(0);
+    size_t total_bytes_read(0);
+    unsigned char last_byte(0);
+    bool end_line_found(false);
+
+    // check file descriptor
+    if (!_is_valid_fd()) {
+        print(log_alert, " file descriptor [%i] to [%s] is invalid. try to reopen.", name().c_str(), _fd, device());
+        _fd = _openDevice(&_oldtio, _baudrate);
+        if (_fd < 0) {
+            return 0;
+        }
+    }
+
+
+	time(&start_time);
+    std::string strReadText;
+
+	while (1) {
+		_safe_to_cancel();
+		// check for timeout
+		time(&end_time);
+		if (difftime(end_time, start_time) > _read_timeout_s) {
+			print(log_error, " nothing received for more than %d seconds", name().c_str(),
+				  _read_timeout_s);
+			break;
+		}
+
+		// now read a single byte
+		ssize_t bytes_read = ::read(_fd, &last_byte, 1);
+		if (bytes_read == 0 || (bytes_read == -1 && errno == EAGAIN)) {
+			// wait 5ms and read again
+			usleep(5000);
+			continue;
+		} else if (bytes_read == -1) {
+			print(log_error, " error reading a byte (%d)", name().c_str(), errno);
+			break;
+		}
+        strReadText.push_back(last_byte);
+        total_bytes_read++;
+
+        if (MeterSOS_S0_Helper::hasEnding(strReadText, "\n\n")) {
+            end_line_found = true;
+            break;
+        }
+
+	} // end while
+    
+    if (end_line_found) {
+        std::vector<std::string> data;
+        MeterSOS_S0_Helper::tokenize(strReadText, ":", data);
+        if (data.size() == 19) {
+
+            char *end = nullptr;
+            size_t deviceId(strtoul(data.at(1).c_str(), &end, 10));
+
+            int dataStart(4);
+            for (int count=0; count < 5; count++) {
+                std::string strIdent(data.at(dataStart));
+                size_t value(strtoul(data.at(dataStart+1).c_str(), &end, 10));
+
+                rds[count].identifier(new StringIdentifier(strIdent));
+                rds[count].time();
+                rds[count].value(value);
+                dataStart += 3;
+
+                std::stringstream ss;
+                ss << "deviceId: [" << deviceId << "] - ID: " << strIdent << " value: " << value;
+                print(log_debug, "read: %s", name().c_str(), ss.str().c_str());
+            }
+            return 5; // return number of good readings so far.  
+        } else {
+            print(log_alert, "tokenize of returned text failed: %lu instead of 19 ELements in text found", name().c_str(), data.size());
+        }
+    }
+
+	return 0; 
+}
+
+bool MeterSOS_S0::_is_valid_fd()
+{
+    auto ret_code = fcntl(_fd, F_GETFL);
+    return ((ret_code != -1) || (errno != EBADF)) ? true : false;
+}
+
+int MeterSOS_S0::_openDevice(struct termios *old_tio, speed_t baudrate) {
+	struct termios tio;
+	memset(&tio, 0, sizeof(struct termios));
+
+	int fd = ::open(device(), O_RDWR | O_NOCTTY | O_NONBLOCK);
+	if (fd < 0) {
+		print(log_alert, "open(%s): %s", name().c_str(), device(), strerror(errno));
+		return ERR;
+	}
+
+	// get old configuration
+	tcgetattr(fd, &tio);
+
+	// backup old configuration to restore it when closing the meter connection
+	memcpy(old_tio, &tio, sizeof(struct termios));
+	/*
+	initialize all control characters
+	default values can be found in /usr/include/termios.h, and are given
+	in the comments, but we don't need them here
+	*/
+	tio.c_cc[VINTR] = 0;    // Ctrl-c
+	tio.c_cc[VQUIT] = 0;    // Ctrl-<backslash>
+	tio.c_cc[VERASE] = 0;   // del
+	tio.c_cc[VKILL] = 0;    // @
+	tio.c_cc[VEOF] = 4;     // Ctrl-d
+	tio.c_cc[VTIME] = 0;    // inter-character timer unused
+	tio.c_cc[VMIN] = 1;     // blocking read until 1 character arrives
+	tio.c_cc[VSWTC] = 0;    // '\0'
+	tio.c_cc[VSTART] = 0;   // Ctrl-q
+	tio.c_cc[VSTOP] = 0;    // Ctrl-s
+	tio.c_cc[VSUSP] = 0;    // Ctrl-z
+	tio.c_cc[VEOL] = 0;     // '\0'
+	tio.c_cc[VREPRINT] = 0; // Ctrl-r
+	tio.c_cc[VDISCARD] = 0; // Ctrl-u
+	tio.c_cc[VWERASE] = 0;  // Ctrl-w
+	tio.c_cc[VLNEXT] = 0;   // Ctrl-v
+	tio.c_cc[VEOL2] = 0;    // '\0'
+
+	tio.c_iflag &= ~(BRKINT | INLCR | IMAXBEL | IXOFF | IXON);
+	tio.c_oflag &= ~(OPOST | ONLCR);
+	tio.c_lflag &= ~(ISIG | ICANON | IEXTEN | ECHO);
+
+	switch (_parity) {
+	case parity_8n1:
+		tio.c_cflag &= ~PARENB;
+		tio.c_cflag &= ~PARODD;
+		tio.c_cflag &= ~CSTOPB;
+		tio.c_cflag &= ~CSIZE;
+		tio.c_cflag |= CS8;
+		break;
+	case parity_7n1:
+		tio.c_cflag &= ~PARENB;
+		tio.c_cflag &= ~PARODD;
+		tio.c_cflag &= ~CSTOPB;
+		tio.c_cflag &= ~CSIZE;
+		tio.c_cflag |= CS7;
+		break;
+	case parity_7e1:
+		tio.c_cflag &= ~CRTSCTS;
+		tio.c_cflag |= PARENB;
+		tio.c_cflag &= ~PARODD;
+		tio.c_cflag &= ~CSTOPB;
+		tio.c_cflag &= ~CSIZE;
+		tio.c_cflag |= CS7;
+		break;
+	case parity_7o1:
+		tio.c_cflag &= ~PARENB;
+		tio.c_cflag |= PARODD;
+		tio.c_cflag &= ~CSTOPB;
+		tio.c_cflag &= ~CSIZE;
+		tio.c_cflag |= CS7;
+		break;
+	}
+	// Set return rules for read to prevent endless waiting
+	tio.c_cc[VTIME] = 50; // inter-character timer  50*0.1
+	tio.c_cc[VMIN] = 0;   // VTIME is timeout counter
+	// now clean the modem line and activate the settings for the port
+
+	tcflush(fd, TCIOFLUSH);
+	// set baudrate
+	cfsetispeed(&tio, baudrate);
+	cfsetospeed(&tio, baudrate);
+
+	// apply new configuration
+	tcsetattr(fd, TCSANOW, &tio);
+
+	return fd;
+}
+
+// snip from kernel end

--- a/src/protocols/MeterSOS_S0.cpp
+++ b/src/protocols/MeterSOS_S0.cpp
@@ -1,10 +1,16 @@
 /**
- * Plaintext protocol according to DIN EN 62056-21
+ * Plaintext protocol of S0 Pulse meter devices
+ *  --> https://www.sossolutions.nl/5-kanaals-s0-pulse-meter-op-usb
  *
- * This protocol uses OBIS codes to identify the readout data
+ * The device is a USB s0 logger device.
  *
- * This is our example protocol. Use this skeleton to add your own
- * protocols and meters.
+ * The protocol is defined as follows:
+ *       ‘ID:x:I:y:M1:a:b:M2:c:d:M3:e:f:M4:g:h:M5:i:j’’
+ *        - x = ID des S0 pulse meter (unique)
+ * 	      - y = number of seconds since last message (default: 10 second)
+ *        - M1,M2,M3,M4,M5 = identifier name for corresponding S0 port on device
+ *        - a,c,e,g,i = number of pulses since last message
+ *        - b,d,f,h,j = total number of pulses since start of device
  *
  * @package vzlogger
  * @copyright Copyright (c) 2011 - 2023, The volkszaehler.org project

--- a/src/protocols/MeterSOS_S0.cpp
+++ b/src/protocols/MeterSOS_S0.cpp
@@ -1,0 +1,297 @@
+/**
+ * Plaintext protocol according to DIN EN 62056-21
+ *
+ * This protocol uses OBIS codes to identify the readout data
+ *
+ * This is our example protocol. Use this skeleton to add your own
+ * protocols and meters.
+ *
+ * @package vzlogger
+ * @copyright Copyright (c) 2011 - 2023, The volkszaehler.org project
+ * @license http://www.gnu.org/licenses/gpl.txt GNU Public License
+ * @author Steffen Vogel <info@steffenvogel.de>
+ * @author Mathias Dalheimer <md@gonium.net>
+ */
+/*
+ * This file is part of volkzaehler.org
+ *
+ * volkzaehler.org is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * volkzaehler.org is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with volkszaehler.org. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <ctype.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/time.h>
+#include <time.h>
+#include <unistd.h>
+
+#include "threads.h"
+
+#include "protocols/MeterSOS_S0.hpp"
+#include <VZException.hpp>
+
+#include <string>
+#include <sstream>
+#include <vector>
+
+
+namespace MeterSOS_S0_Helper {
+
+bool hasEnding (const std::string &fullString, const std::string &ending) {
+    if (fullString.length() >= ending.length()) {
+        return (0 == fullString.compare (fullString.length() - ending.length(), ending.length(), ending));
+    } 
+
+    return false;
+}
+
+void tokenize(const std::string &text, const std::string &delimiter, std::vector<std::string> &data){
+    size_t start = text.find_first_not_of(delimiter);
+    size_t end = start;
+
+    while (start != std::string::npos){
+        end = text.find(delimiter, start);
+        data.push_back(text.substr(start, end-start));
+        start = text.find_first_not_of(delimiter, end);
+    }
+}
+
+};
+
+MeterSOS_S0::MeterSOS_S0(std::list<Option> &options)
+	: Protocol("sos_s0"), _device(""), _read_timeout_s(10) {
+	OptionList option_list;
+
+	// connection
+	try {
+		_device = option_list.lookup_string(options, "device");
+		if (!_device.length()) {
+			throw vz::VZException("device without length");
+		}
+	} catch (vz::VZException &e) {
+		print(log_alert, "Missing device or host", name().c_str());
+		throw;
+	}
+
+	// baudrate and parity are hard coded for this devices
+    _baudrate = B9600;
+	_parity = parity_7n1;
+
+	try {
+		_read_timeout_s = option_list.lookup_int(options, "read_timeout");
+	} catch (vz::OptionNotFoundException &e) {
+		// use default: 10s from constructor
+	} catch (vz::VZException &e) {
+		print(log_alert, "Failed to parse read_timeout", name().c_str());
+		throw;
+	}
+}
+
+MeterSOS_S0::~MeterSOS_S0() {
+}
+
+int MeterSOS_S0::open() {
+
+	if (_device.length() > 0) {
+		_fd = _openDevice(&_oldtio, _baudrate);
+	} 
+
+	return (_fd < 0) ? ERR : SUCCESS;
+}
+
+int MeterSOS_S0::close() {
+	return ::close(_fd);
+}
+
+ssize_t MeterSOS_S0::read(std::vector<Reading> &rds, size_t max_readings) {
+
+    time_t start_time(0);
+    time_t end_time(0);
+    size_t total_bytes_read(0);
+    unsigned char last_byte(0);
+    bool end_line_found(false);
+
+    // check file descriptor
+    if (!_is_valid_fd()) {
+        print(log_alert, " file descriptor [%i] to [%s] is invalid. try to reopen.", name().c_str(), _fd, device());
+        _fd = _openDevice(&_oldtio, _baudrate);
+        if (_fd < 0) {
+            return 0;
+        }
+    }
+
+
+	time(&start_time);
+    std::string strReadText;
+
+	while (1) {
+		_safe_to_cancel();
+		// check for timeout
+		time(&end_time);
+		if (difftime(end_time, start_time) > _read_timeout_s) {
+			print(log_error, " nothing received for more than %d seconds", name().c_str(),
+				  _read_timeout_s);
+			break;
+		}
+
+		// now read a single byte
+		ssize_t bytes_read = ::read(_fd, &last_byte, 1);
+		if (bytes_read == 0 || (bytes_read == -1 && errno == EAGAIN)) {
+			// wait 5ms and read again
+			usleep(5000);
+			continue;
+		} else if (bytes_read == -1) {
+			print(log_error, " error reading a byte (%d)", name().c_str(), errno);
+			break;
+		}
+        strReadText.push_back(last_byte);
+        total_bytes_read++;
+
+        if (MeterSOS_S0_Helper::hasEnding(strReadText, "\n\n")) {
+            end_line_found = true;
+            break;
+        }
+
+	} // end while
+    
+    if (end_line_found) {
+        std::vector<std::string> data;
+        MeterSOS_S0_Helper::tokenize(strReadText, ":", data);
+        if (data.size() == 19) {
+
+            char *end = nullptr;
+            size_t deviceId(strtoul(data.at(1).c_str(), &end, 10));
+
+            int dataStart(4);
+            for (int count=0; count < 5; count++) {
+                std::string strIdent(data.at(dataStart));
+                size_t value(strtoul(data.at(dataStart+1).c_str(), &end, 10));
+
+                rds[count].identifier(new StringIdentifier(strIdent));
+                rds[count].time();
+                rds[count].value(value);
+                dataStart += 3;
+
+                std::stringstream ss;
+                ss << "deviceId: [" << deviceId << "] - ID: " << strIdent << " value: " << value;
+                print(log_debug, "read: %s", name().c_str(), ss.str().c_str());
+            }
+            return 5; // return number of good readings so far.  
+        } else {
+            print(log_alert, "tokenize of returned text failed: %lu instead of 19 ELements in text found", name().c_str(), data.size());
+        }
+    }
+
+	return 0; 
+}
+
+bool MeterSOS_S0::_is_valid_fd()
+{
+    auto ret_code = fcntl(_fd, F_GETFL);
+    return ((ret_code != -1) || (errno != EBADF)) ? true : false;
+}
+
+int MeterSOS_S0::_openDevice(struct termios *old_tio, speed_t baudrate) {
+	struct termios tio;
+	memset(&tio, 0, sizeof(struct termios));
+
+	int fd = ::open(device(), O_RDWR | O_NOCTTY | O_NONBLOCK);
+	if (fd < 0) {
+		print(log_alert, "open(%s): %s", name().c_str(), device(), strerror(errno));
+		return ERR;
+	}
+
+	// get old configuration
+	tcgetattr(fd, &tio);
+
+	// backup old configuration to restore it when closing the meter connection
+	memcpy(old_tio, &tio, sizeof(struct termios));
+	/*
+	initialize all control characters
+	default values can be found in /usr/include/termios.h, and are given
+	in the comments, but we don't need them here
+	*/
+	tio.c_cc[VINTR] = 0;    // Ctrl-c
+	tio.c_cc[VQUIT] = 0;    // Ctrl-<backslash>
+	tio.c_cc[VERASE] = 0;   // del
+	tio.c_cc[VKILL] = 0;    // @
+	tio.c_cc[VEOF] = 4;     // Ctrl-d
+	tio.c_cc[VTIME] = 0;    // inter-character timer unused
+	tio.c_cc[VMIN] = 1;     // blocking read until 1 character arrives
+	tio.c_cc[VSWTC] = 0;    // '\0'
+	tio.c_cc[VSTART] = 0;   // Ctrl-q
+	tio.c_cc[VSTOP] = 0;    // Ctrl-s
+	tio.c_cc[VSUSP] = 0;    // Ctrl-z
+	tio.c_cc[VEOL] = 0;     // '\0'
+	tio.c_cc[VREPRINT] = 0; // Ctrl-r
+	tio.c_cc[VDISCARD] = 0; // Ctrl-u
+	tio.c_cc[VWERASE] = 0;  // Ctrl-w
+	tio.c_cc[VLNEXT] = 0;   // Ctrl-v
+	tio.c_cc[VEOL2] = 0;    // '\0'
+
+	tio.c_iflag &= ~(BRKINT | INLCR | IMAXBEL | IXOFF | IXON);
+	tio.c_oflag &= ~(OPOST | ONLCR);
+	tio.c_lflag &= ~(ISIG | ICANON | IEXTEN | ECHO);
+
+	switch (_parity) {
+	case parity_8n1:
+		tio.c_cflag &= ~PARENB;
+		tio.c_cflag &= ~PARODD;
+		tio.c_cflag &= ~CSTOPB;
+		tio.c_cflag &= ~CSIZE;
+		tio.c_cflag |= CS8;
+		break;
+	case parity_7n1:
+		tio.c_cflag &= ~PARENB;
+		tio.c_cflag &= ~PARODD;
+		tio.c_cflag &= ~CSTOPB;
+		tio.c_cflag &= ~CSIZE;
+		tio.c_cflag |= CS7;
+		break;
+	case parity_7e1:
+		tio.c_cflag &= ~CRTSCTS;
+		tio.c_cflag |= PARENB;
+		tio.c_cflag &= ~PARODD;
+		tio.c_cflag &= ~CSTOPB;
+		tio.c_cflag &= ~CSIZE;
+		tio.c_cflag |= CS7;
+		break;
+	case parity_7o1:
+		tio.c_cflag &= ~PARENB;
+		tio.c_cflag |= PARODD;
+		tio.c_cflag &= ~CSTOPB;
+		tio.c_cflag &= ~CSIZE;
+		tio.c_cflag |= CS7;
+		break;
+	}
+	// Set return rules for read to prevent endless waiting
+	tio.c_cc[VTIME] = 50; // inter-character timer  50*0.1
+	tio.c_cc[VMIN] = 0;   // VTIME is timeout counter
+	// now clean the modem line and activate the settings for the port
+
+	tcflush(fd, TCIOFLUSH);
+	// set baudrate
+	cfsetispeed(&tio, baudrate);
+	cfsetospeed(&tio, baudrate);
+
+	// apply new configuration
+	tcsetattr(fd, TCSANOW, &tio);
+
+	return fd;
+}
+
+// snip from kernel end

--- a/tests/mocks/CMakeLists.txt
+++ b/tests/mocks/CMakeLists.txt
@@ -34,6 +34,7 @@ add_executable(mock_metermap
 	${mock_sml_sources}
 	../../src/protocols/MeterFluksoV2.cpp
 	../../src/protocols/MeterW1therm.cpp
+	../../src/protocols/MeterSOS_S0.cpp
 	../../src/Reading.cpp
 	../../src/Obis.cpp
 	../../src/ltqnorm.cpp

--- a/tests/ut_meter.cpp
+++ b/tests/ut_meter.cpp
@@ -20,6 +20,7 @@
 #include "../src/protocols/MeterFluksoV2.cpp"
 #include "../src/protocols/MeterRandom.cpp"
 #include "../src/protocols/MeterS0.cpp"
+#include "../src/protocols/MeterSOS_S0.cpp"
 
 TEST(meter, meter_lookup_protocol) {
 	ASSERT_EQ(ERR_NOT_FOUND, meter_lookup_protocol(NULL, NULL));


### PR DESCRIPTION
Implementation a new device protocol: sos_s0 

The 5 Channel S0 USB Pulse meter is a device based on Arduino Micro. It collects and buffers S0 impulse from up to five S0 devices and sends the retrieved S0-IMpulses within a 10 second timeframe to the serial port (e.g. /dev/ttyACM0) available via standard USB driver. The protocol is documented by the vendor.
The device is available here: https://www.sossolutions.nl/5-kanaals-s0-pulse-meter-op-usb

This change adds a new protocol "sos_s0" to vzlogger. The implementation opens the device port, applies the hardcoded baud rate and parity setting (9600/7/n/1) and reads the data from the serial device. 
The read data is provided to volkzaehler middleware by the usual ways.


