### PR TITLE
Add ability to configure SML meter workarounds

### DIFF
--- a/etc/vzlogger.conf
+++ b/etc/vzlogger.conf
@@ -68,6 +68,8 @@
 
             "aggtime": 10,                  // aggregate meter readings and send middleware update after <aggtime> seconds
 
+            "dzg_fix_negative_values": false, // work around wrongly encoded negative values on some DZG meters
+
             "channels": [{
                 "api": "volkszaehler",      // middleware api, default volkszaehler
                 "uuid": "fde8f1d0-c5d0-11e0-856e-f9e4360ced10",

--- a/etc/vzlogger_generic.schema.json
+++ b/etc/vzlogger_generic.schema.json
@@ -517,6 +517,11 @@
                             "type": "boolean",
                             "default": false,
                             "description": "use the local time for reading timestamp?"
+                        },
+                        "dzg_fix_negative_values": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "work around wrongly encoded negative values on some DZG meters"
                         }
                     },
                 "required": ["protocol", "device", "baudrate", "parity"]
@@ -559,6 +564,11 @@
                             "type": "boolean",
                             "default": false,
                             "description": "use the local time for reading timestamp?"
+                        },
+                        "dzg_fix_negative_values": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "work around wrongly encoded negative values on some DZG meters"
                         }
                     },
                 "required": ["protocol", "host", "baudrate", "parity"]

--- a/include/protocols/MeterSML.hpp
+++ b/include/protocols/MeterSML.hpp
@@ -65,6 +65,7 @@ class MeterSML : public vz::protocol::Protocol {
 	parity_type_t _parity;
 	std::string _pull;
 	bool _use_local_time;
+	sml_workarounds _sml_workarounds;
 
 	int _fd;                 /* file descriptor of port */
 	struct termios _old_tio; /* required to reset port */


### PR DESCRIPTION
Make use of libsml's workaround options to apply a workaround for DZG meters. This builds upon the changes from [libsml PR #133](https://github.com/volkszaehler/libsml/pull/133).

Should the new configuration option be documented somewhere in addition to the json schema?