### PR TITLE
Update MeterW1therm.cpp to catch erroneous temperature values

### DIFF
--- a/src/protocols/MeterW1therm.cpp
+++ b/src/protocols/MeterW1therm.cpp
@@ -83,8 +83,50 @@ bool MeterW1therm::W1sysHWif::readTemp(const std::string &device, double &value)
 			print(log_debug, "CRC not ok from %s (%s)", "w1t", dev.c_str(), buffer);
 		} else {
 			// crc ok
-			// now parse t=<value>
+			// now check for other errors:
 			if (fgets(buffer, 100, fp)) { // e.g. 07 01 55 00 7f ff 0c 10 18 t=16437
+				
+				///// Start of new code: Catch DS18B20-specific errors.       /////
+				/// For reference: https://github.com/cpetrich/counterfeit_DS18B20
+				/// Check byte 6 of scratchpad to recognize error readings. 
+				/// Genuine DS18B20 compute byte 6 as the difference from 
+				/// 00001111 & <byte 0> to 00010000; most clones always use 0x0c.
+				/// Genuine DS18B20 are still in the 00000xxxxxxx address range 
+				/// as of 2023; clones are not. 
+				
+				// Check for sensor family DS18B20 via device == "28*":
+				if (device[0]=='2' && device[1]=='8') {
+					if (!strncmp(buffer,"00 00 00 00 00 00 00 00 00",26)) {
+						// According to DS18B20 datasheet, this scratchpad-reading MUST be wrong. 
+						print(log_debug, "only zeroes from %s (%s), "
+							"the 1wire-bus is probably unstable", "w1t", dev.c_str(), buffer);
+						return false;
+						}
+					// if (buffer == "?? ?? ?? ?? ?? ?? 0c*"), maybe an error has happened:
+					if (buffer[18]=='0' && buffer[19]=='c') {
+						// only do this handling for genuine DS18B20, e.g. device="28-0000*":
+						if (device[3]=='0' && buffer[4]=='0' && buffer[5]=='0' && buffer[6]=='0') {
+							// if (buffer == "50 05*"), 0x0550/16 = 85 degrees Celsius
+							if (!strncmp(buffer,"50 05",5)) {
+								// Sensor returned default boot-up value; did not complete temperature conversion.
+								print(log_debug, "85 degree error from %s (%s), "
+									"the 1wire-bus is probably unstable", "w1t", dev.c_str(), buffer);
+								return false;
+							}
+							// (if buffer == "ff 07*"), 0x07ff/16 = 127.9375 degrees Celsius
+							if (!strncmp(buffer,"ff 07",5)) {
+								// Sensor returned code for insufficient power during temperature conversion. 
+								// This can happen in parasitic 2-wire circuits with floating Vcc pins. 
+								print(log_debug, "insufficient power error from %s (%s), "
+									"maybe Vcc was left floating", "w1t", dev.c_str(), buffer);
+								return false;
+							}
+						}
+					}
+				}
+				///// End of new code. /////
+				
+				// now parse t=<value>
 				char *pos = strstr(buffer, "t=");
 				if (pos) {
 					pos += 2;

--- a/src/protocols/MeterW1therm.cpp
+++ b/src/protocols/MeterW1therm.cpp
@@ -63,6 +63,55 @@ bool MeterW1therm::W1sysHWif::scanW1devices() {
 	return false;
 }
 
+// check for DS18B20-specific errors
+// For reference: https://github.com/cpetrich/counterfeit_DS18B20
+// Check byte 6 of scratchpad to recognize error readings.
+// Genuine DS18B20 compute byte 6 as the difference from
+// 00001111 & <byte 0> to 00010000; most clones always use 0x0c.
+// Genuine DS18B20 are still in the 00000xxxxxxx address range
+// as of 2023; clones are not.
+bool MeterW1therm::check_quirks(const std::string &device, char buffer[100]) {
+	// Check for sensor family DS18B20 via device == "28*":
+	if (device[0] != '2' || device[1] != '8')
+		return true;
+
+	if (!strncmp(buffer, "00 00 00 00 00 00 00 00 00", 26)) {
+		// According to DS18B20 datasheet, this scratchpad-reading MUST be wrong.
+		print(log_debug,
+			  "only zeroes from %s (%s), "
+			  "the 1wire-bus is probably unstable",
+			  "w1t", dev.c_str(), buffer);
+		return false;
+	}
+	// if (buffer == "?? ?? ?? ?? ?? ?? 0c*"), maybe an error has happened:
+	if (buffer[18] == '0' && buffer[19] == 'c') {
+		// only do this handling for genuine DS18B20, e.g. device="28-0000*":
+		if (device[3] == '0' && buffer[4] == '0' && buffer[5] == '0' && buffer[6] == '0') {
+			// if (buffer == "50 05*"), 0x0550/16 = 85 degrees Celsius
+			if (!strncmp(buffer, "50 05", 5)) {
+				// Sensor returned default boot-up value; did not complete temperature
+				// conversion.
+				print(log_debug,
+					  "85 degree error from %s (%s), "
+					  "the 1wire-bus is probably unstable",
+					  "w1t", dev.c_str(), buffer);
+				return false;
+			}
+			// (if buffer == "ff 07*"), 0x07ff/16 = 127.9375 degrees Celsius
+			if (!strncmp(buffer, "ff 07", 5)) {
+				// Sensor returned code for insufficient power during temperature conversion.
+				// This can happen in parasitic 2-wire circuits with floating Vcc pins.
+				print(log_debug,
+					  "insufficient power error from %s (%s), "
+					  "maybe Vcc was left floating",
+					  "w1t", dev.c_str(), buffer);
+				return false;
+			}
+		}
+	}
+	return true;
+}
+
 bool MeterW1therm::W1sysHWif::readTemp(const std::string &device, double &value) {
 	bool toret = false;
 	// read from /sys/bus/w1/devices/<device>/w1_slave
@@ -83,49 +132,10 @@ bool MeterW1therm::W1sysHWif::readTemp(const std::string &device, double &value)
 			print(log_debug, "CRC not ok from %s (%s)", "w1t", dev.c_str(), buffer);
 		} else {
 			// crc ok
-			// now check for other errors:
 			if (fgets(buffer, 100, fp)) { // e.g. 07 01 55 00 7f ff 0c 10 18 t=16437
-				
-				///// Start of new code: Catch DS18B20-specific errors.       /////
-				/// For reference: https://github.com/cpetrich/counterfeit_DS18B20
-				/// Check byte 6 of scratchpad to recognize error readings. 
-				/// Genuine DS18B20 compute byte 6 as the difference from 
-				/// 00001111 & <byte 0> to 00010000; most clones always use 0x0c.
-				/// Genuine DS18B20 are still in the 00000xxxxxxx address range 
-				/// as of 2023; clones are not. 
-				
-				// Check for sensor family DS18B20 via device == "28*":
-				if (device[0]=='2' && device[1]=='8') {
-					if (!strncmp(buffer,"00 00 00 00 00 00 00 00 00",26)) {
-						// According to DS18B20 datasheet, this scratchpad-reading MUST be wrong. 
-						print(log_debug, "only zeroes from %s (%s), "
-							"the 1wire-bus is probably unstable", "w1t", dev.c_str(), buffer);
-						return false;
-						}
-					// if (buffer == "?? ?? ?? ?? ?? ?? 0c*"), maybe an error has happened:
-					if (buffer[18]=='0' && buffer[19]=='c') {
-						// only do this handling for genuine DS18B20, e.g. device="28-0000*":
-						if (device[3]=='0' && buffer[4]=='0' && buffer[5]=='0' && buffer[6]=='0') {
-							// if (buffer == "50 05*"), 0x0550/16 = 85 degrees Celsius
-							if (!strncmp(buffer,"50 05",5)) {
-								// Sensor returned default boot-up value; did not complete temperature conversion.
-								print(log_debug, "85 degree error from %s (%s), "
-									"the 1wire-bus is probably unstable", "w1t", dev.c_str(), buffer);
-								return false;
-							}
-							// (if buffer == "ff 07*"), 0x07ff/16 = 127.9375 degrees Celsius
-							if (!strncmp(buffer,"ff 07",5)) {
-								// Sensor returned code for insufficient power during temperature conversion. 
-								// This can happen in parasitic 2-wire circuits with floating Vcc pins. 
-								print(log_debug, "insufficient power error from %s (%s), "
-									"maybe Vcc was left floating", "w1t", dev.c_str(), buffer);
-								return false;
-							}
-						}
-					}
-				}
-				///// End of new code. /////
-				
+				if (!check_quirks(device, buffer))
+					return false;
+
 				// now parse t=<value>
 				char *pos = strstr(buffer, "t=");
 				if (pos) {


### PR DESCRIPTION
As announced here: https://www.photovoltaikforum.com/thread/199267-blitzeinschlag-in-der-nachbarschaft-hat-mir-den-vz-lahmgelegt/?postID=3459011#post3459011 , I've written some code to catch 
1) the erroneous 0°C temperature reading,
2) the 85°C error reading and
3) the 127.9375°C error reading 
before they end up in the database. This is based upon work from Chris Petrich:  https://github.com/cpetrich/counterfeit_DS18B20

A similar check for conversion success was added to w1_therm kernel module in 2020: https://github.com/torvalds/linux/blame/305230142ae0637213bf6e04f6d9f10bbcb74af8/drivers/w1/slaves/w1_therm.c#L1186-L1197

So when do these readings occur? 
1) can happen when the bus is unstable due to bad design (some sensors in star topology, long wiring, too many sensors, pullup inadequate, EMI etc.). The busmaster will receive only zeroes when it reads the 8 byte scratchpad from a DS18B20. Unfortunately, this will result in a correct CRC checksum (which is also zero). Fortunately, according to the DS18B20 datasheet, it is impossible for a scratchpad to contain only zeroes (i.e. byte 6 won't be zero if byte 0 is zero, the alarm values at byte 2&3 won't be both zero etc.). So this reading can be safely discarded as wrong. 
2) happens when a genuine DS18B20 has to report a temperature before it could finish the temperature conversion. Or, if the first conversion command was never received by the DS18B20 due to an unstable bus. Luckily, scratchpad byte 6 will tell the difference (at least for genuine DS18B20). For counterfeit sensors, I disabled this check, as they mostly do not handle byte 6 as genuine DS18B20 do (see cpetrich). Sensor discrimination is done via sensor address (see cpetrich). 
This discrimination will work until the serial numbers of genuine DS18B20 reach 0x0001xxxxxxxx. Currently, we are at 0x00000fxxxxxx. I estimate this won't be a problem before 2050. 
3) was never encountered by myself. According to cpetrich, it can happen when a parasitic circuit with some DS18B20 happens to have at least one DS18B20 with Vcc left floating (and not tied to ground as the datasheet demands). Also, temperature readings above 125°C are outside sensor specification and probably always fishy. 

In my opinion, all of these readings should not end up as spikes in the temperature database, but preferable as debug error in the vzlogger logfile. 

As of yet, I still have little experience writing C++, so probably I did not write the best possible code. Please comment on what could be better.

I did not yet test this code on a RasPi. I plan to set up a test system in the next two weeks. 