### PR TITLE
Align binary reference with apt package from cloudsmith

### DIFF
--- a/etc/vzlogger.service
+++ b/etc/vzlogger.service
@@ -3,7 +3,7 @@ Description=vzlogger
 After=syslog.target network.target ntp.service
 
 [Service]
-ExecStart=/usr/local/bin/vzlogger -c /etc/vzlogger.conf
+ExecStart=/usr/bin/vzlogger -c /etc/vzlogger.conf
 ExecReload=
 StandardOutput=null
 


### PR DESCRIPTION
The cloudsmith apt packages install vzlogger to /usr/bin:

```
dpkg -L vzlogger
...
/usr/bin/vzlogger
...

```
However, the service file references:
```
ExecStart=/usr/local/bin/vzlogger -c /etc/vzlogger.conf
```

This PR fixes the binary reference in the service definition