### PR TITLE
Fix compile issues for docker build

### DIFF
--- a/include/PushData.hpp
+++ b/include/PushData.hpp
@@ -5,6 +5,7 @@
 #ifndef __push_data_hpp_
 #define __push_data_hpp_
 
+#include <cstdint>
 #include <list>
 #include <pthread.h>
 #include <queue>


### PR DESCRIPTION
Fixes a compile issue when building a docker image via
```
docker build -t vzlogger .
```

This leads to following error on the apline linux image which is used for the build:

```
In file included from /vzlogger/src/PushData.cpp:5:
 /vzlogger/include/PushData.hpp:18:27: error: 'int64_t' was not declared in this scope
    18 |         typedef std::pair<int64_t, double> DataTuple;
       |                           ^~~~~~~
 /vzlogger/include/PushData.hpp:14:1: note: 'int64_t' is defined in header '<cstdint>'; did you forget to '#include <cstdint>'?
    13 | #include <utility> // for std::pair
   +++ |+#include <cstdint>
```