### PR TITLE
Apply clang-tidy modernize-use-nullptr to Obis.cpp

### DIFF
--- a/include/Channel.hpp
+++ b/include/Channel.hpp
@@ -53,13 +53,13 @@ class Channel {
 		// Copy the owner's shared pointer for the logging_thread into this member.
 		this_shared->_this_forthread = this_shared;
 		// .. and pass the raw Channel*
-		pthread_create(&this_shared->_thread, NULL, &logging_thread, (void *)this_shared.get());
+		pthread_create(&this_shared->_thread, nullptr, &logging_thread, (void *)this_shared.get());
 		this_shared->_thread_running = true;
 	}
 
 	void join() {
 		if (_thread_running) {
-			pthread_join(_thread, NULL);
+			pthread_join(_thread, nullptr);
 			_thread_running = false;
 			_this_forthread.reset();
 		}
@@ -80,7 +80,7 @@ class Channel {
 			throw vz::VZException("No identifier defined.");
 		return _identifier;
 	}
-	int64_t time_ms() const { return _last == NULL ? 0 : _last->time_ms(); }
+	int64_t time_ms() const { return _last == nullptr ? 0 : _last->time_ms(); }
 
 	const char *uuid() const { return _uuid.c_str(); }
 	const std::string apiProtocol() { return _apiProtocol; }

--- a/include/Json.hpp
+++ b/include/Json.hpp
@@ -9,7 +9,7 @@ class Json {
 	typedef vz::shared_ptr<Json> Ptr;
 
 	Json(struct json_object *jso) : _jso(jso){};
-	~Json() { _jso = NULL; };
+	~Json() { _jso = nullptr; };
 
 	struct json_object *Object() {
 		return _jso;

--- a/include/Reading.hpp
+++ b/include/Reading.hpp
@@ -179,7 +179,7 @@ class Reading {
 
 	int64_t time_ms() const { return ((int64_t)_time.tv_sec) * 1e3 + (_time.tv_usec / 1e3); };
 	long time_s() const { return _time.tv_sec; }; // return only the seconds (always rounding down)
-	void time() { gettimeofday(&_time, NULL); }
+	void time() { gettimeofday(&_time, nullptr); }
 	void time(struct timeval const &v) { _time = v; }
 	void time(struct timespec const &v) {
 		_time.tv_sec = v.tv_sec;

--- a/src/Buffer.cpp
+++ b/src/Buffer.cpp
@@ -36,9 +36,9 @@
 
 #include "Buffer.hpp"
 
-Buffer::Buffer() : _keep(32), _last_avg(0) {
+Buffer::Buffer() : _keep(32), _last_avg(nullptr) {
 	_newValues = false;
-	pthread_mutex_init(&_mutex, NULL);
+	pthread_mutex_init(&_mutex, nullptr);
 	_aggmode = NONE;
 }
 
@@ -54,7 +54,7 @@ void Buffer::aggregate(int aggtime, bool aggFixedInterval) {
 
 	lock();
 	if (_aggmode == MAX) {
-		Reading *latest = NULL;
+		Reading *latest = nullptr;
 		double aggvalue = -DBL_MAX;
 		for (iterator it = _sent.begin(); it != _sent.end(); it++) {
 			if (!it->deleted()) {
@@ -86,7 +86,7 @@ void Buffer::aggregate(int aggtime, bool aggFixedInterval) {
 		// we assume buffer values are already sorted by time here! TODO: is this always true?
 		// otherwise a sort by time would be needed but this might conflict with _last_avg
 
-		Reading *latest = NULL;
+		Reading *latest = nullptr;
 		double aggvalue = 0;
 		double aggtimespan = 0.0;
 		unsigned int aggcount = 0;
@@ -130,7 +130,7 @@ void Buffer::aggregate(int aggtime, bool aggFixedInterval) {
 			}
 		}
 	} else if (_aggmode == SUM) {
-		Reading *latest = NULL;
+		Reading *latest = nullptr;
 		double aggvalue = 0;
 		for (iterator it = _sent.begin(); it != _sent.end(); it++) {
 			if (!it->deleted()) {

--- a/src/Channel.cpp
+++ b/src/Channel.cpp
@@ -39,7 +39,7 @@ int Channel::instances = 0;
 Channel::Channel(const std::list<Option> &pOptions, const std::string apiProtocol,
 				 const std::string uuid, ReadingIdentifier::Ptr pIdentifier)
 	: _thread_running(false), _options(pOptions), _buffer(new Buffer()), _identifier(pIdentifier),
-	  _last(0), _uuid(uuid), _apiProtocol(apiProtocol), _duplicates(0) {
+	  _last(nullptr), _uuid(uuid), _apiProtocol(apiProtocol), _duplicates(0) {
 	id = instances++;
 
 	// set channel name
@@ -86,7 +86,7 @@ Channel::Channel(const std::list<Option> &pOptions, const std::string apiProtoco
 		throw;
 	}
 
-	pthread_cond_init(&condition, NULL); // initialize thread syncronization helpers
+	pthread_cond_init(&condition, nullptr); // initialize thread syncronization helpers
 }
 
 /**

--- a/src/Config_Options.cpp
+++ b/src/Config_Options.cpp
@@ -40,21 +40,21 @@ static const char *option_type_str[] = {"null",   "boolean", "double", "int",
 										"object", "array",   "string"};
 
 Config_Options::Config_Options()
-	: _config("/etc/vzlogger.conf"), _log(""), _pds(0), _port(8080), _verbosity(0),
+	: _config("/etc/vzlogger.conf"), _log(""), _pds(nullptr), _port(8080), _verbosity(0),
 	  _comet_timeout(30), _buffer_length(-1), _retry_pause(15), _local(false), _foreground(false),
 	  _time_machine(false) {
-	_logfd = NULL;
+	_logfd = nullptr;
 }
 
 Config_Options::Config_Options(const std::string filename)
-	: _config(filename), _log(""), _pds(0), _port(8080), _verbosity(0), _comet_timeout(30),
+	: _config(filename), _log(""), _pds(nullptr), _port(8080), _verbosity(0), _comet_timeout(30),
 	  _buffer_length(-1), _retry_pause(15), _local(false), _foreground(false),
 	  _time_machine(false) {
-	_logfd = NULL;
+	_logfd = nullptr;
 }
 
 void Config_Options::config_parse(MapContainer &mappings) {
-	struct json_object *json_cfg = NULL;
+	struct json_object *json_cfg = nullptr;
 	struct json_tokener *json_tok = json_tokener_new();
 
 	char buf[JSON_FILE_BUF_SIZE];
@@ -62,12 +62,12 @@ void Config_Options::config_parse(MapContainer &mappings) {
 
 	/* open configuration file */
 	FILE *file = fopen(_config.c_str(), "r");
-	if (file == NULL) {
-		print(log_alert, "Cannot open configfile %s: %s", NULL, _config.c_str(),
+	if (file == nullptr) {
+		print(log_alert, "Cannot open configfile %s: %s", nullptr, _config.c_str(),
 			  strerror(errno)); /* why didn't the file open? */
 		throw vz::VZException("Cannot open configfile.");
 	} else {
-		print(log_info, "Start parsing configuration from %s", NULL, _config.c_str());
+		print(log_info, "Start parsing configuration from %s", nullptr, _config.c_str());
 	}
 
 #ifdef HAVE_CPP_REGEX
@@ -79,7 +79,7 @@ void Config_Options::config_parse(MapContainer &mappings) {
 	while (fgets(buf, JSON_FILE_BUF_SIZE, file)) {
 		line++;
 
-		if (json_cfg != NULL) {
+		if (json_cfg != nullptr) {
 #ifdef HAVE_CPP_REGEX
 			// let's ignore whitespace and single line comments here:
 			if (!std::regex_match((const char *)buf, regex)) {
@@ -88,7 +88,7 @@ void Config_Options::config_parse(MapContainer &mappings) {
 			std::string strline(buf);
 			if (!std::all_of(strline.begin(), strline.end(), isspace)) {
 #endif
-				print(log_alert, "extra data after end of configuration in %s:%d", NULL,
+				print(log_alert, "extra data after end of configuration in %s:%d", nullptr,
 					  _config.c_str(), line);
 				throw vz::VZException("extra data after end of configuration");
 			}
@@ -97,10 +97,10 @@ void Config_Options::config_parse(MapContainer &mappings) {
 			json_cfg = json_tokener_parse_ex(json_tok, buf, strlen(buf));
 
 			if (json_tok->err > 1) {
-				print(log_alert, "Error in %s:%d %s at offset %d", NULL, _config.c_str(), line,
+				print(log_alert, "Error in %s:%d %s at offset %d", nullptr, _config.c_str(), line,
 					  json_tokener_error_desc(json_tok->err), json_tok->char_offset);
 				json_object_put(json_cfg);
-				json_cfg = 0;
+				json_cfg = nullptr;
 				throw vz::VZException("Parse configuaration failed.");
 			}
 		}
@@ -110,7 +110,7 @@ void Config_Options::config_parse(MapContainer &mappings) {
 	fclose(file);
 	json_tokener_free(json_tok);
 
-	if (json_cfg == NULL)
+	if (json_cfg == nullptr)
 		throw vz::VZException("configuration file incomplete, missing closing braces/parens?");
 
 	try {
@@ -147,7 +147,7 @@ void Config_Options::config_parse(MapContainer &mappings) {
 					} else if (strcmp(key, "index") == 0 && local_type == json_type_boolean) {
 						_channel_index = json_object_get_boolean(local_value);
 					} else {
-						print(log_alert, "Ignoring invalid field or type: %s=%s (%s)", NULL, key,
+						print(log_alert, "Ignoring invalid field or type: %s=%s (%s)", nullptr, key,
 							  json_object_get_string(local_value), option_type_str[local_type]);
 					}
 				}
@@ -172,7 +172,7 @@ void Config_Options::config_parse(MapContainer &mappings) {
 					mqttClient = new MqttClient(value);
 					if (!mqttClient->isConfigured()) {
 						delete mqttClient;
-						mqttClient = 0;
+						mqttClient = nullptr;
 						print(log_debug, "mqtt client not configured. stopped.", "mqtt");
 					}
 				} else
@@ -183,7 +183,7 @@ void Config_Options::config_parse(MapContainer &mappings) {
 			else if ((strcmp(key, "i_have_a_time_machine") == 0) && type == json_type_boolean) {
 				_time_machine = json_object_get_boolean(value);
 			} else {
-				print(log_alert, "Ignoring invalid field or type: %s=%s (%s)", NULL, key,
+				print(log_alert, "Ignoring invalid field or type: %s=%s (%s)", nullptr, key,
 					  json_object_get_string(value), option_type_str[type]);
 			}
 		}
@@ -195,7 +195,7 @@ void Config_Options::config_parse(MapContainer &mappings) {
 		throw;
 	}
 
-	print(log_debug, "Have %d meters.", NULL, mappings.size());
+	print(log_debug, "Have %d meters.", nullptr, mappings.size());
 	json_object_put(json_cfg); /* free allocated memory */
 }
 
@@ -222,7 +222,7 @@ void Config_Options::config_parse_meter(MapContainer &mappings, Json::Ptr jso) {
 	/* init meter */
 	MeterMap metermap(options);
 
-	print(log_info, "New meter initialized (protocol=%s)", NULL /*(mapping*/,
+	print(log_info, "New meter initialized (protocol=%s)", nullptr /*(mapping*/,
 		  meter_get_details(metermap.meter()->protocolId())->name);
 
 	/* init channels */
@@ -236,11 +236,11 @@ void Config_Options::config_parse_meter(MapContainer &mappings, Json::Ptr jso) {
 
 void Config_Options::config_parse_channel(Json &jso, MeterMap &mapping) {
 	std::list<Option> options;
-	const char *uuid = NULL;
-	const char *id_str = NULL;
+	const char *uuid = nullptr;
+	const char *id_str = nullptr;
 	std::string apiProtocol_str;
 
-	print(log_debug, "Configure channel.", NULL);
+	print(log_debug, "Configure channel.", nullptr);
 	json_object_object_foreach(jso.Object(), key, value) {
 		enum json_type type = json_object_get_type(value);
 
@@ -263,17 +263,17 @@ void Config_Options::config_parse_channel(Json &jso, MeterMap &mapping) {
 	}
 
 	/* check uuid and middleware */
-	if (uuid == NULL) {
-		print(log_alert, "Missing UUID", NULL);
+	if (uuid == nullptr) {
+		print(log_alert, "Missing UUID", nullptr);
 		throw vz::VZException("Missing UUID");
 	}
 	if (!config_validate_uuid(uuid)) {
-		print(log_alert, "Invalid UUID: %s", NULL, uuid);
+		print(log_alert, "Invalid UUID: %s", nullptr, uuid);
 		throw vz::VZException("Invalid UUID.");
 	}
 	// check if identifier is set. If not, use default
-	if (id_str == NULL) {
-		print(log_error, "Identifier is not set. Using default value 'NilIdentifier'.", NULL);
+	if (id_str == nullptr) {
+		print(log_error, "Identifier is not set. Using default value 'NilIdentifier'.", nullptr);
 		id_str = "NilIdentifier";
 	}
 	// if (middleware == NULL) {
@@ -291,7 +291,7 @@ void Config_Options::config_parse_channel(Json &jso, MeterMap &mapping) {
 	} catch (vz::VZException &e) {
 		std::stringstream oss;
 		oss << e.what();
-		print(log_alert, "Invalid id: %s due to: '%s'", NULL, id_str, oss.str().c_str());
+		print(log_alert, "Invalid id: %s due to: '%s'", nullptr, id_str, oss.str().c_str());
 		throw vz::VZException("Invalid reader.");
 	}
 

--- a/src/CurlSessionProvider.cpp
+++ b/src/CurlSessionProvider.cpp
@@ -57,7 +57,7 @@ CURL *CurlSessionProvider::get_easy_session(
 	std::string key, int timeout) // this is intended to block if the handle for the current key is
 								  // in use and single_session_per_key
 {
-	CURL *toRet = 0;
+	CURL *toRet = nullptr;
 	// thread safe lock here to access the map:
 	assert(0 == pthread_mutex_lock(&_map_mutex));
 	map_it it = _easy_handle_map.find(key);
@@ -99,7 +99,7 @@ void CurlSessionProvider::return_session(
 	assert(0 == pthread_mutex_lock(&_map_mutex));
 	CurlUsage &cu = _easy_handle_map[key];
 	assert(eh == cu.eh);
-	eh = 0;
+	eh = nullptr;
 	cu.inUse = false;
 	pthread_mutex_unlock(&cu.mutex);
 	pthread_mutex_unlock(&_map_mutex);
@@ -117,4 +117,4 @@ bool CurlSessionProvider::inUse(std::string key) {
 }
 
 // global var:
-CurlSessionProvider *curlSessionProvider = 0;
+CurlSessionProvider *curlSessionProvider = nullptr;

--- a/src/Meter.cpp
+++ b/src/Meter.cpp
@@ -72,7 +72,7 @@ static const meter_details_t protocols[] = {
 	METER_DETAIL(oms, OMS, "OMS (M-BUS) protocol based devices", 100),
 #endif
 	//{} /* stop condition for iterator */
-	METER_DETAIL(none, NULL, NULL, 0),
+	METER_DETAIL(none, nullptr, nullptr, 0),
 };
 
 Meter::Meter(std::list<Option> pOptions) : _name("meter") {
@@ -262,5 +262,5 @@ const meter_details_t *meter_get_details(meter_protocol_t protocol) {
 			return it;
 		}
 	}
-	return NULL;
+	return nullptr;
 }

--- a/src/MeterMap.cpp
+++ b/src/MeterMap.cpp
@@ -54,7 +54,7 @@ void MeterMap::start() {
 			_meter->open();
 		} catch (vz::ConnectionException &e) {
 			if (_meter->skip()) {
-				print(log_warning, "Skipping meter %s", NULL, _meter->name());
+				print(log_warning, "Skipping meter %s", nullptr, _meter->name());
 				return;
 			} else {
 				throw;
@@ -62,7 +62,7 @@ void MeterMap::start() {
 		}
 
 		print(log_info, "Meter connection established", _meter->name());
-		pthread_create(&_thread, NULL, &reading_thread, (void *)this);
+		pthread_create(&_thread, nullptr, &reading_thread, (void *)this);
 		print(log_debug, "Meter thread started", _meter->name());
 
 		print(log_debug, "Meter is opened. Starting channels.", _meter->name());
@@ -87,7 +87,7 @@ void MeterMap::cancel() { // is called from MapContainer::quit which is called f
 		}
 		print(log_finest, "MeterMap::cancel wait for readingthread", _meter->name());
 		pthread_cancel(_thread); // readingthread
-		pthread_join(_thread, NULL);
+		pthread_join(_thread, nullptr);
 		_thread_running = false;
 		print(log_finest, "MeterMap::cancel wait for meter::close", _meter->name());
 		_meter->close();

--- a/src/Obis.cpp
+++ b/src/Obis.cpp
@@ -100,7 +100,7 @@ static obis_alias_t aliases[] = {
 	{Obis(255, 255, 16, 8, 2, 255), "lg-counter-lt", "Sum active energy (T2)"},
 
 	//	Stop condition for iterator
-	{Obis(DC, DC, DC, DC, DC, DC), NULL, NULL},
+	{Obis(DC, DC, DC, DC, DC, DC), nullptr, nullptr},
 };
 
 obis_alias_t *obis_get_aliases() { return aliases; }
@@ -211,7 +211,7 @@ int Obis::parse(const char *str) {
 }
 
 int Obis::lookup_alias(const char *alias) {
-	for (const obis_alias_t *it = aliases; it != NULL && !it->id.isAllNotGiven(); it++) {
+	for (const obis_alias_t *it = aliases; it != nullptr && !it->id.isAllNotGiven(); it++) {
 		if (strcmp(it->name, alias) == 0) {
 			*this = it->id;
 			return SUCCESS;

--- a/src/Options.cpp
+++ b/src/Options.cpp
@@ -102,7 +102,7 @@ Option::~Option() {
 	if (_type == type_array || _type == type_object) {
 		if (value.jso)
 			json_object_put(value.jso);
-		value.jso = 0;
+		value.jso = nullptr;
 	}
 }
 

--- a/src/PushData.cpp
+++ b/src/PushData.cpp
@@ -8,7 +8,7 @@
 #include <assert.h>
 #include <time.h>
 
-PushDataServer::PushDataServer(struct json_object *option) : _headers(0) {
+PushDataServer::PushDataServer(struct json_object *option) : _headers(nullptr) {
 	if (option) {
 		// todo parse param option (is a json_type_array with len>0
 		// expected is each array item to be an object with key "url"
@@ -112,7 +112,7 @@ std::string PushDataServer::generateJson(PushDataList::DataMap &dataMap) {
 
 bool PushDataServer::send(const std::string &middleware, const std::string &datastr) {
 	bool toRet = true;
-	CURL *curl = curlSessionProvider ? curlSessionProvider->get_easy_session(middleware) : 0;
+	CURL *curl = curlSessionProvider ? curlSessionProvider->get_easy_session(middleware) : nullptr;
 	if (!curl) {
 		print(log_alert, "send no curl session!", "push");
 		return false;
@@ -120,7 +120,7 @@ bool PushDataServer::send(const std::string &middleware, const std::string &data
 
 	CURLresponse response;
 	response.size = 0;
-	response.data = 0;
+	response.data = nullptr;
 	CURLcode curl_code;
 	long int http_code;
 
@@ -177,7 +177,7 @@ size_t PushDataServer::curl_custom_write_callback(void *ptr, size_t size, size_t
 	CURLresponse *response = static_cast<CURLresponse *>(data);
 
 	response->data = (char *)realloc(response->data, response->size + realsize + 1);
-	if (response->data == NULL) { // out of memory!
+	if (response->data == nullptr) { // out of memory!
 		print(log_alert, "Cannot allocate memory data=%p response->size=%zu realsize=%zu", "push",
 			  data, response->size, realsize);
 		exit(EXIT_FAILURE);
@@ -190,8 +190,8 @@ size_t PushDataServer::curl_custom_write_callback(void *ptr, size_t size, size_t
 	return realsize;
 }
 
-PushDataList::PushDataList() : _next(0), _map_mutex(PTHREAD_MUTEX_INITIALIZER) {
-	pthread_cond_init(&_cond, NULL);
+PushDataList::PushDataList() : _next(nullptr), _map_mutex(PTHREAD_MUTEX_INITIALIZER) {
+	pthread_cond_init(&_cond, nullptr);
 }
 
 PushDataList::~PushDataList() {
@@ -219,7 +219,7 @@ void PushDataList::add(const std::string &uuid, const int64_t &time_ms, const do
 }
 
 PushDataList::DataMap *PushDataList::waitForData() {
-	DataMap *toRet = 0;
+	DataMap *toRet = nullptr;
 	assert(0 == pthread_mutex_lock(&_map_mutex));
 	int rc = 0;
 
@@ -234,7 +234,7 @@ PushDataList::DataMap *PushDataList::waitForData() {
 
 	if (rc == 0) {
 		toRet = _next;
-		_next = 0; // change ownership to caller. We will create new one on next add()
+		_next = nullptr; // change ownership to caller. We will create new one on next add()
 	}
 	pthread_mutex_unlock(&_map_mutex);
 
@@ -242,7 +242,7 @@ PushDataList::DataMap *PushDataList::waitForData() {
 }
 
 // global var:
-PushDataList *pushDataList = 0;
+PushDataList *pushDataList = nullptr;
 volatile bool endThread = false;
 
 void *push_data_thread(void *arg) {
@@ -257,7 +257,7 @@ void *push_data_thread(void *arg) {
 	}
 
 	print(log_debug, "Stopped push_data_thread", "push");
-	return 0;
+	return nullptr;
 }
 
 void end_push_data_thread() { endThread = true; }

--- a/src/api.cpp
+++ b/src/api.cpp
@@ -76,8 +76,8 @@ size_t curl_custom_write_callback(void *ptr, size_t size, size_t nmemb, void *da
 	CURLresponse *response = static_cast<CURLresponse *>(data);
 
 	response->data = (char *)realloc(response->data, response->size + realsize + 1);
-	if (response->data == NULL) { /* out of memory! */
-		print(log_alert, "Cannot allocate memory", NULL);
+	if (response->data == nullptr) { /* out of memory! */
+		print(log_alert, "Cannot allocate memory", nullptr);
 		exit(EXIT_FAILURE);
 	}
 
@@ -126,7 +126,7 @@ vz::Api::Api(Channel::Ptr ch)
 			curl_version());                                         /* build user agent */
 	sprintf(url, "%s/data/%s.json", _ch->middleware(), _ch->uuid()); /* build url */
 
-	_api.headers = NULL;
+	_api.headers = nullptr;
 	_api.headers = curl_slist_append(_api.headers, "Content-type: application/json");
 	_api.headers = curl_slist_append(_api.headers, "Accept: application/json");
 	_api.headers = curl_slist_append(_api.headers, agent);

--- a/src/api/CurlIF.cpp
+++ b/src/api/CurlIF.cpp
@@ -26,7 +26,7 @@
 #include <VZException.hpp>
 #include <api/CurlIF.hpp>
 
-vz::api::CurlIF::CurlIF() : _headers(0) {
+vz::api::CurlIF::CurlIF() : _headers(nullptr) {
 	_curl = curl_easy_init();
 	if (!_curl) {
 		throw vz::VZException("CURL: cannot create handle.");
@@ -35,7 +35,7 @@ vz::api::CurlIF::CurlIF() : _headers(0) {
 
 vz::api::CurlIF::~CurlIF() {
 	curl_easy_cleanup(_curl);
-	if (_headers != NULL)
+	if (_headers != nullptr)
 		curl_slist_free_all(_headers);
 }
 
@@ -43,11 +43,11 @@ void vz::api::CurlIF::addHeader(const std::string value) {
 	_headers = curl_slist_append(_headers, value.c_str());
 }
 void vz::api::CurlIF::clearHeader() {
-	if (_headers != NULL)
+	if (_headers != nullptr)
 		curl_slist_free_all(_headers);
-	_headers = NULL;
+	_headers = nullptr;
 }
 void vz::api::CurlIF::commitHeader() {
-	if (_headers != NULL)
+	if (_headers != nullptr)
 		curl_easy_setopt(handle(), CURLOPT_HTTPHEADER, _headers);
 }

--- a/src/api/InfluxDB.cpp
+++ b/src/api/InfluxDB.cpp
@@ -41,7 +41,8 @@
 extern Config_Options options;
 
 vz::api::InfluxDB::InfluxDB(const Channel::Ptr &ch, const std::list<Option> &pOptions)
-	: ApiIF(ch), _response(new vz::api::CurlResponse()), _last_timestamp(0), _lastReadingSent(0) {
+	: ApiIF(ch), _response(new vz::api::CurlResponse()), _last_timestamp(0),
+	  _lastReadingSent(nullptr) {
 	OptionList optlist;
 	print(log_debug, "InfluxDB API initialize", ch->name());
 
@@ -57,7 +58,7 @@ vz::api::InfluxDB::InfluxDB(const Channel::Ptr &ch, const std::list<Option> &pOp
 		throw;
 	}
 
-	_token_header = NULL;
+	_token_header = nullptr;
 	try {
 		_token = optlist.lookup_string(pOptions, "token");
 		print(log_finest, "api InfluxDB using login Token: %s", ch->name(), _token.c_str());
@@ -247,8 +248,9 @@ void vz::api::InfluxDB::send() {
 	Buffer::Ptr buf = channel()->buffer();
 	Buffer::iterator it;
 
-	_api.curl =
-		curlSessionProvider ? curlSessionProvider->get_easy_session(_host + channel()->uuid()) : 0;
+	_api.curl = curlSessionProvider
+					? curlSessionProvider->get_easy_session(_host + channel()->uuid())
+					: nullptr;
 
 	if (!_api.curl) {
 		throw vz::VZException("CURL: cannot create handle.");

--- a/src/api/MySmartGrid.cpp
+++ b/src/api/MySmartGrid.cpp
@@ -134,7 +134,7 @@ vz::api::MySmartGrid::MySmartGrid(Channel::Ptr ch, std::list<Option> pOptions)
 vz::api::MySmartGrid::~MySmartGrid() {}
 
 void vz::api::MySmartGrid::send() {
-	json_object *json_obj = NULL;
+	json_object *json_obj = nullptr;
 	char digest[255];
 
 	const char *json_str;
@@ -142,7 +142,7 @@ void vz::api::MySmartGrid::send() {
 	CURLcode curl_code;
 
 	// check if we want to send
-	time_t now = time(NULL);
+	time_t now = time(nullptr);
 
 	if (_first_ts > 0) {
 		if ((now - first_ts()) < interval()) {
@@ -161,7 +161,7 @@ void vz::api::MySmartGrid::send() {
 		break;
 	}
 	json_str = json_object_to_json_string(json_obj);
-	if (json_str == NULL || strcmp(json_str, "null") == 0) {
+	if (json_str == nullptr || strcmp(json_str, "null") == 0) {
 		print(log_debug, "JSON request body is null. Nothing to send now.", channel()->name());
 		json_object_put(json_obj); // TODO untested!
 		return;
@@ -257,7 +257,7 @@ void vz::api::MySmartGrid::_send(const std::string &url, json_object *json_obj) 
 	curl_easy_setopt(_curlIF.handle(), CURLOPT_URL, url.c_str());
 
 	json_str = json_object_to_json_string(json_obj);
-	if (json_str == NULL || strcmp(json_str, "null") == 0) {
+	if (json_str == nullptr || strcmp(json_str, "null") == 0) {
 		print(log_debug, "JSON request body is null. Nothing to send now.", channel()->name());
 		return;
 	}
@@ -320,7 +320,7 @@ void vz::api::MySmartGrid::api_parse_exception(char *err, size_t n) {
 		struct json_object *json_obj;
 		bool found = json_object_object_get_ex(json_obj_in, "exception", &json_obj);
 		if (found && json_obj) {
-			struct json_object *j2 = 0, *j3 = 0;
+			struct json_object *j2 = nullptr, *j3 = nullptr;
 			(void)json_object_object_get_ex(json_obj, "type",
 											&j2); // we rely on ..._get_string to handle null
 			(void)json_object_object_get_ex(json_obj, "message",
@@ -355,10 +355,10 @@ json_object *vz::api::MySmartGrid::_apiDevice(Buffer::Ptr buf) {
 	buf->clean();
 
 	if (_first_ts > 0) { // send lifesign
-		_first_ts = time(NULL);
+		_first_ts = time(nullptr);
 		return _json_object_heartbeat();
 	} else { // send  device registration
-		_first_ts = time(NULL);
+		_first_ts = time(nullptr);
 		return _json_object_registration();
 	}
 }
@@ -506,7 +506,7 @@ json_object *vz::api::MySmartGrid::_json_object_measurements(Buffer::Ptr buf) {
 		print(log_debug, "==> %ld, %lf - %ld", channel()->name(), timestamp, it->value(), value);
 	}
 	if (_values.size() < 1 || (_values.size() < 2 && _first_counter == 0)) {
-		return NULL;
+		return nullptr;
 	}
 
 	for (it = _values.begin(); it != _values.end(); it++) {

--- a/src/api/Volkszaehler.cpp
+++ b/src/api/Volkszaehler.cpp
@@ -45,7 +45,7 @@ extern Config_Options options;
 const int MAX_CHUNK_SIZE = 64;
 
 vz::api::Volkszaehler::Volkszaehler(Channel::Ptr ch, std::list<Option> pOptions)
-	: ApiIF(ch), _last_timestamp(0), _lastReadingSent(0) {
+	: ApiIF(ch), _last_timestamp(0), _lastReadingSent(nullptr) {
 	OptionList optlist;
 	char agent[255];
 
@@ -83,7 +83,7 @@ vz::api::Volkszaehler::Volkszaehler(Channel::Ptr ch, std::list<Option> pOptions)
 	_url.append(channel()->uuid());
 	_url.append(".json");
 
-	_api.headers = NULL;
+	_api.headers = nullptr;
 	_api.headers = curl_slist_append(_api.headers, "Content-type: application/json");
 	_api.headers = curl_slist_append(_api.headers, "Accept: application/json");
 	_api.headers = curl_slist_append(_api.headers, agent);
@@ -103,19 +103,20 @@ void vz::api::Volkszaehler::send() {
 	CURLcode curl_code;
 
 	// initialize response
-	response.data = NULL;
+	response.data = nullptr;
 	response.size = 0;
 
 	json_obj = api_json_tuples(channel()->buffer());
 	json_str = json_object_to_json_string(json_obj);
-	if (json_str == NULL || strcmp(json_str, "null") == 0) {
+	if (json_str == nullptr || strcmp(json_str, "null") == 0) {
 		print(log_debug, "JSON request body is null. Nothing to send now.", channel()->name());
 		return;
 	}
 
-	_api.curl = curlSessionProvider
-					? curlSessionProvider->get_easy_session(_middleware)
-					: 0; // TODO add option to use parallel sessions. Simply add uuid() to the key.
+	_api.curl =
+		curlSessionProvider
+			? curlSessionProvider->get_easy_session(_middleware)
+			: nullptr; // TODO add option to use parallel sessions. Simply add uuid() to the key.
 	if (!_api.curl) {
 		throw vz::VZException("CURL: cannot create handle.");
 	}
@@ -230,7 +231,7 @@ json_object *vz::api::Volkszaehler::api_json_tuples(Buffer::Ptr buf) {
 	buf->clean();
 
 	if (_values.size() < 1) {
-		return NULL;
+		return nullptr;
 	}
 
 	json_object *json_tuples = json_object_new_array();
@@ -337,8 +338,8 @@ size_t vz::api::curl_custom_write_callback(void *ptr, size_t size, size_t nmemb,
 	CURLresponse *response = static_cast<CURLresponse *>(data);
 
 	response->data = (char *)realloc(response->data, response->size + realsize + 1);
-	if (response->data == NULL) { // out of memory!
-		print(log_alert, "Cannot allocate memory", NULL);
+	if (response->data == nullptr) { // out of memory!
+		print(log_alert, "Cannot allocate memory", nullptr);
 		exit(EXIT_FAILURE);
 	}
 

--- a/src/api/hmac.cpp
+++ b/src/api/hmac.cpp
@@ -16,12 +16,12 @@ void hmac_sha1(char *digest, const unsigned char *data, size_t dataLen,
 #elif OPENSSL_VERSION_NUMBER < 0x30000000L
 	HMAC_CTX *hmacContext = HMAC_CTX_new();
 
-	HMAC_Init_ex(hmacContext, secretKey, secretLen, EVP_sha1(), NULL);
+	HMAC_Init_ex(hmacContext, secretKey, secretLen, EVP_sha1(), nullptr);
 	HMAC_Update(hmacContext, data, dataLen);
 #else
 	EVP_MD_CTX *evpContext = EVP_MD_CTX_new();
-	EVP_PKEY *pkey = EVP_PKEY_new_raw_private_key(EVP_PKEY_HMAC, NULL, secretKey, secretLen);
-	EVP_DigestSignInit(evpContext, NULL, EVP_sha1(), NULL, pkey);
+	EVP_PKEY *pkey = EVP_PKEY_new_raw_private_key(EVP_PKEY_HMAC, nullptr, secretKey, secretLen);
+	EVP_DigestSignInit(evpContext, nullptr, EVP_sha1(), nullptr, pkey);
 	EVP_PKEY_free(pkey);
 	EVP_DigestSignUpdate(evpContext, data, dataLen);
 #endif

--- a/src/local.cpp
+++ b/src/local.cpp
@@ -99,7 +99,7 @@ void add_ch_to_localbuffer(Channel &ch) {
 json_object *api_json_tuples(const char *uuid) {
 
 	if (!uuid)
-		return NULL;
+		return nullptr;
 	pthread_mutex_lock(&localbuffer_mutex);
 	LIST_ChannelData &l = localbuffer[uuid];
 
@@ -107,7 +107,7 @@ json_object *api_json_tuples(const char *uuid) {
 
 	if (l.size() < 1) {
 		pthread_mutex_unlock(&localbuffer_mutex);
-		return NULL;
+		return nullptr;
 	}
 
 	json_object *json_tuples = json_object_new_array();
@@ -134,7 +134,7 @@ MHD_RESULT handle_request(void *cls, struct MHD_Connection *connection, const ch
 	// mapping between meters and channels
 	MapContainer *mappings = static_cast<MapContainer *>(cls);
 
-	struct MHD_Response *response = NULL;
+	struct MHD_Response *response = nullptr;
 	const char *mode = MHD_lookup_connection_value(connection, MHD_GET_ARGUMENT_KIND, "mode");
 
 	try {
@@ -145,7 +145,7 @@ MHD_RESULT handle_request(void *cls, struct MHD_Connection *connection, const ch
 
 			struct json_object *json_obj = json_object_new_object();
 			struct json_object *json_data = json_object_new_array();
-			struct json_object *json_exception = NULL;
+			struct json_object *json_exception = nullptr;
 
 			const char *uuid = url + 1; // strip leading slash
 			const char *json_str;

--- a/src/mqtt.cpp
+++ b/src/mqtt.cpp
@@ -11,7 +11,7 @@
 #include <unistd.h>
 
 // global var:
-MqttClient *mqttClient = 0;
+MqttClient *mqttClient = nullptr;
 volatile bool endMqttClientThread = false;
 
 // class impl.
@@ -57,14 +57,15 @@ MqttClient::MqttClient(struct json_object *option) : _enabled(false) {
 				if (qos >= 0 && qos <= 2) {
 					_qos = qos;
 				} else {
-					print(log_alert, "Ignoring invalid QoS value %d, assuming default", NULL, qos);
+					print(log_alert, "Ignoring invalid QoS value %d, assuming default", nullptr,
+						  qos);
 				}
 			} else if (strcmp(key, "timestamp") == 0 && local_type == json_type_boolean) {
 				_timestamp = json_object_get_boolean(local_value);
 			} else if (strcmp(key, "id") == 0 && local_type == json_type_string) {
 				_id = json_object_get_string(local_value);
 			} else {
-				print(log_alert, "Ignoring invalid field or type: %s=%s", NULL, key,
+				print(log_alert, "Ignoring invalid field or type: %s=%s", nullptr, key,
 					  json_object_get_string(local_value));
 			}
 		}
@@ -273,8 +274,8 @@ void MqttClient::publish(Channel::Ptr ch, Reading &rds, bool aggregate) {
 	if (!entry._announced && entry._announceValues.size()) {
 		for (auto &v : entry._announceValues) {
 			std::string name = entry._announceName + v.first;
-			int res = mosquitto_publish(_mcs, 0, name.c_str(), v.second.length(), v.second.c_str(),
-										_qos, _retain);
+			int res = mosquitto_publish(_mcs, nullptr, name.c_str(), v.second.length(),
+										v.second.c_str(), _qos, _retain);
 			if (res != MOSQ_ERR_SUCCESS) {
 				print(log_finest, "mosquitto_publish announce \"%s\" failed: %s", "mqtt",
 					  name.c_str(), mosquitto_strerror(res));
@@ -288,7 +289,7 @@ void MqttClient::publish(Channel::Ptr ch, Reading &rds, bool aggregate) {
 	if ((entry._sendAgg and aggregate) or (entry._sendRaw && !aggregate)) {
 		lock.unlock(); // we can unlock here already
 		std::string payload;
-		struct json_object *payload_obj = NULL;
+		struct json_object *payload_obj = nullptr;
 
 		if (_timestamp) {
 			payload_obj = json_object_new_object();
@@ -301,12 +302,12 @@ void MqttClient::publish(Channel::Ptr ch, Reading &rds, bool aggregate) {
 
 		print(log_finest, "publish %s=%s", "mqtt", topic.c_str(), payload.c_str());
 
-		int res = mosquitto_publish(_mcs, 0, topic.c_str(), payload.length(), payload.c_str(), _qos,
-									_retain);
+		int res = mosquitto_publish(_mcs, nullptr, topic.c_str(), payload.length(), payload.c_str(),
+									_qos, _retain);
 		if (res != MOSQ_ERR_SUCCESS) {
 			print(log_finest, "mosquitto_publish failed: %s", "mqtt", mosquitto_strerror(res));
 		}
-		if (payload_obj != NULL) {
+		if (payload_obj != nullptr) {
 			json_object_put(payload_obj);
 		}
 	}
@@ -356,7 +357,7 @@ void *mqtt_client_thread(void *arg) {
 	}
 
 	print(log_debug, "Stopped mqtt_client_thread", "mqtt");
-	return 0;
+	return nullptr;
 }
 
 void end_mqtt_client_thread() { endMqttClientThread = true; }

--- a/src/protocols/MeterD0.cpp
+++ b/src/protocols/MeterD0.cpp
@@ -56,7 +56,7 @@ MeterD0::MeterD0(std::list<Option> &options)
 	: Protocol("d0"), _host(""), _device(""), _auto_ack(false), _wait_sync_end(false),
 	  _read_timeout_s(10), _baudrate_change_delay_ms(0), _reaction_time_ms(200) // default to 200ms
 	  ,
-	  _dump_fd(0), _old_mode(NONE), _dump_pos(0) {
+	  _dump_fd(nullptr), _old_mode(NONE), _dump_pos(0) {
 	OptionList optlist;
 
 	// connection
@@ -92,7 +92,7 @@ MeterD0::MeterD0(std::list<Option> &options)
 			hs[2] = 0;
 			strncpy(hs, hex.c_str() + i, 2);
 			char hx[2];
-			hx[0] = strtol(hs, NULL, 16);
+			hx[0] = strtol(hs, nullptr, 16);
 			_pull.append(hx, 1);
 		}
 		print(log_debug, "pullseq len:%d found", name().c_str(), _pull.size());
@@ -113,7 +113,7 @@ MeterD0::MeterD0(std::list<Option> &options)
 				char hs[3];
 				strncpy(hs, hex.c_str() + i, 2);
 				char hx[2];
-				hx[0] = strtol(hs, NULL, 16);
+				hx[0] = strtol(hs, nullptr, 16);
 				_ack.append(hx, 1);
 			}
 			print(log_debug, "ackseq len:%d found %s, %x", name().c_str(), _ack.size(),
@@ -357,7 +357,7 @@ int MeterD0::close() {
 	dump_file(CTRL, "closed\n"); // here we add a \n as this will be the last data
 	if (_dump_fd) {
 		(void)fclose(_dump_fd);
-		_dump_fd = 0;
+		_dump_fd = nullptr;
 	}
 	return ::close(_fd);
 }
@@ -788,7 +788,7 @@ ssize_t MeterD0::read(std::vector<Reading> &rds, size_t max_readings) {
 				case 'F':
 					print(log_debug, "Parsed reading (OBIS code=%s, value=%s, unit=%s)",
 						  name().c_str(), obis_code, value, unit);
-					rds[number_of_tuples].value(strtod(value, NULL));
+					rds[number_of_tuples].value(strtod(value, nullptr));
 
 					try {
 						Obis obis(obis_code);
@@ -839,7 +839,7 @@ int MeterD0::_openSocket(const char *node, const char *service) {
 		return ERR;
 	}
 
-	getaddrinfo(node, service, NULL, &ais);
+	getaddrinfo(node, service, nullptr, &ais);
 	memcpy(&sin, ais->ai_addr, ais->ai_addrlen);
 	freeaddrinfo(ais);
 
@@ -992,11 +992,11 @@ void MeterD0::dump_file(DUMP_MODE mode, const char *buf, size_t len) {
 
 		fwrite(ctrl_end, 1, strlen(ctrl_end), _dump_fd);
 		fflush(_dump_fd); // flush on each mode change
-		const char *s = 0, *e = 0;
+		const char *s = nullptr, *e = nullptr;
 		switch (mode) {
 		case CTRL:
 			s = ctrl_start;
-			e = 0;
+			e = nullptr;
 			break;
 		case DUMP_IN:
 			s = dump_in_start;

--- a/src/protocols/MeterExec.cpp
+++ b/src/protocols/MeterExec.cpp
@@ -136,15 +136,15 @@ int MeterExec::open() {
 	print(log_debug, "MeterExec::open: Executing command line '%s'", name().c_str(), command());
 	_pipe = popen(command(), "r");
 
-	if (_pipe == NULL) {
+	if (_pipe == nullptr) {
 		print(log_alert, "MeterExec::open: popen(%s) failed with: %s", name().c_str(), command(),
 			  strerror(errno));
 		return ERR;
 	}
 
-	if (_pipe != NULL) {
+	if (_pipe != nullptr) {
 		pclose(_pipe);
-		_pipe = NULL;
+		_pipe = nullptr;
 	}
 
 	return SUCCESS;
@@ -154,7 +154,7 @@ int MeterExec::close() { return SUCCESS; }
 
 ssize_t MeterExec::read(std::vector<Reading> &rds, size_t n) {
 	char buffer[256];
-	char *string = 0;
+	char *string = nullptr;
 
 	unsigned int i = 0;
 
@@ -202,10 +202,10 @@ ssize_t MeterExec::read(std::vector<Reading> &rds, size_t n) {
 					}
 					if (string) {
 						free(string);
-						string = 0;
+						string = nullptr;
 					}
 				} else { // just reading a value per line
-					rds[i].value(strtod(buffer, NULL));
+					rds[i].value(strtod(buffer, nullptr));
 					rds[i].time();
 					ReadingIdentifier *rid(new StringIdentifier(""));
 					rds[i].identifier(rid);

--- a/src/protocols/MeterFile.cpp
+++ b/src/protocols/MeterFile.cpp
@@ -161,7 +161,7 @@ int MeterFile::open() {
 
 	_fd = fopen(path(), "r");
 
-	if (_fd == NULL) {
+	if (_fd == nullptr) {
 		print(log_alert, "fopen(%s): %s", name().c_str(), path(), strerror(errno));
 		return ERR;
 	}
@@ -182,7 +182,7 @@ int MeterFile::close() {
 ssize_t MeterFile::read(std::vector<Reading> &rds, size_t n) {
 
 	char line[256], *endptr;
-	char *string = 0;
+	char *string = nullptr;
 
 	// wait for file change via inotify
 	const int EVENTSIZE = sizeof(struct inotify_event) + NAME_MAX + 1;
@@ -269,7 +269,7 @@ ssize_t MeterFile::read(std::vector<Reading> &rds, size_t n) {
 			}
 			if (string) {
 				free(string);
-				string = 0;
+				string = nullptr;
 			}
 		} else { // just reading a value per line
 			rds[i].value(strtod(line, &endptr));

--- a/src/protocols/MeterFluksoV2.cpp
+++ b/src/protocols/MeterFluksoV2.cpp
@@ -87,7 +87,7 @@ ssize_t MeterFluksoV2::read(std::vector<Reading> &rds, size_t n) {
 
 	char *time_str = strsep(&cursor, " \t"); /* first token is the timestamp */
 	struct timeval time;
-	time.tv_sec = strtol(time_str, NULL, 10);
+	time.tv_sec = strtol(time_str, nullptr, 10);
 	time.tv_usec = 0; /* no millisecond resolution available */
 
 	while (cursor) {

--- a/src/protocols/MeterOCR.cpp
+++ b/src/protocols/MeterOCR.cpp
@@ -678,11 +678,11 @@ int debounce(int iprev, double fnew) {
 MeterOCR::RecognizerNeedle::~RecognizerNeedle() {}
 
 MeterOCR::MeterOCR(const std::list<Option> &options)
-	: Protocol("ocr"), _last_image(0), _use_v4l2(false), _v4l2_fps(5), _v4l2_skip_frames(0),
-	  _v4l2_fd(-1), _v4l2_buffers(0), _v4l2_nbuffers(0), _v4l2_cap_size_x(320),
+	: Protocol("ocr"), _last_image(nullptr), _use_v4l2(false), _v4l2_fps(5), _v4l2_skip_frames(0),
+	  _v4l2_fd(-1), _v4l2_buffers(nullptr), _v4l2_nbuffers(0), _v4l2_cap_size_x(320),
 	  _v4l2_cap_size_y(240), _min_x(INT_MAX), _min_y(INT_MAX), _max_x(INT_MIN), _max_y(INT_MIN),
 	  _notify_fd(-1), _forced_file_changed(true), _impulses(0), _rotate(0.0), _autofix_range(0),
-	  _autofix_x(-1), _autofix_y(-1), _last_reads(0), _generate_debug_image(false) {
+	  _autofix_x(-1), _autofix_y(-1), _last_reads(nullptr), _generate_debug_image(false) {
 	OptionList optlist;
 
 	try {
@@ -766,7 +766,7 @@ MeterOCR::MeterOCR(const std::list<Option> &options)
 			// for each object:
 			for (int i = 0; i < nrboxes; i++) {
 				struct json_object *jb = json_object_array_get_idx(jso, i);
-				Recognizer *r = 0;
+				Recognizer *r = nullptr;
 
 				// check type, default to tesseract
 				std::string rtype("tesseract");
@@ -839,13 +839,13 @@ int MeterOCR::open() {
 		// check  (open/close) file on each reading, so we check here just once
 		FILE *_fd = fopen(_file.c_str(), "r");
 
-		if (_fd == NULL) {
+		if (_fd == nullptr) {
 			print(log_error, "fopen(%s): %s", name().c_str(), _file.c_str(), strerror(errno));
 			return ERR;
 		}
 
 		(void)fclose(_fd);
-		_fd = NULL;
+		_fd = nullptr;
 	} else { // v4l2 device:
 		struct stat st;
 		if (-1 == stat(_file.c_str(), &st)) {
@@ -1112,7 +1112,7 @@ bool MeterOCR::initV4L2Dev(unsigned int w, unsigned int h) {
 
 		_v4l2_buffers[_v4l2_nbuffers].length = buf.length;
 		_v4l2_buffers[_v4l2_nbuffers].start =
-			mmap(NULL /* start anywhere */, buf.length, PROT_READ | PROT_WRITE /* required */,
+			mmap(nullptr /* start anywhere */, buf.length, PROT_READ | PROT_WRITE /* required */,
 				 MAP_SHARED /* recommended */, _v4l2_fd, buf.m.offset);
 
 		if (MAP_FAILED == _v4l2_buffers[_v4l2_nbuffers].start) {
@@ -1345,7 +1345,7 @@ ssize_t MeterOCR::read(std::vector<Reading> &rds, size_t max_reads) {
 	if (max_reads < 1)
 		return 0;
 
-	Pix *image = 0;
+	Pix *image = nullptr;
 
 	if (!_use_v4l2) {
 		if (!isNotifiedFileChanged() && !_forced_file_changed)
@@ -1394,7 +1394,7 @@ ssize_t MeterOCR::read(std::vector<Reading> &rds, size_t max_reads) {
 		int skip = _v4l2_skip_frames + 1;
 		do {
 			do {
-				r = select(_v4l2_fd + 1, &fds, NULL, NULL, &tv);
+				r = select(_v4l2_fd + 1, &fds, nullptr, nullptr, &tv);
 			} while (-1 == r && EINTR == errno);
 			if (0 == r) {
 				// timeout
@@ -1413,7 +1413,7 @@ ssize_t MeterOCR::read(std::vector<Reading> &rds, size_t max_reads) {
 					return 0;
 				}
 			} else {
-				Pix *im = 0;
+				Pix *im = nullptr;
 				(void)readV4l2Frame(im, false);
 			}
 		} while (--skip);
@@ -1422,7 +1422,7 @@ ssize_t MeterOCR::read(std::vector<Reading> &rds, size_t max_reads) {
 		print(log_finest, "frame ready!", name().c_str());
 	}
 
-	PIXA *debugPixa = _generate_debug_image ? pixaCreate(0) : 0;
+	PIXA *debugPixa = _generate_debug_image ? pixaCreate(0) : nullptr;
 
 	// rotate image if parameter set:
 	if (fabs(_rotate) >= 0.1) {
@@ -1432,7 +1432,7 @@ ssize_t MeterOCR::read(std::vector<Reading> &rds, size_t max_reads) {
 		if (image_rot) {
 			pixDestroy(&image);
 			image = image_rot;
-			image_rot = 0;
+			image_rot = nullptr;
 		}
 		// for debugging to see the rotated picture:
 		if (debugPixa)
@@ -1556,7 +1556,7 @@ ssize_t MeterOCR::read(std::vector<Reading> &rds, size_t max_reads) {
 	// we provide those values to the recognizers even if not impulses wanted
 	if (_last_reads) {
 		delete _last_reads;
-		_last_reads = 0;
+		_last_reads = nullptr;
 	}
 	if (!wasNAN)
 		_last_reads =

--- a/src/protocols/MeterOCRTesseract.cpp
+++ b/src/protocols/MeterOCRTesseract.cpp
@@ -89,7 +89,7 @@ sudo cp tesseract-ocr/tessdata/deu-frak.traineddata /usr/local/share/tessdata/
 #include <tesseract/baseapi.h>
 
 MeterOCR::RecognizerTesseract::RecognizerTesseract(struct json_object *jr)
-	: Recognizer("tesseract", jr), api(0), _gamma(1.0), _gamma_min(50), _gamma_max(120),
+	: Recognizer("tesseract", jr), api(nullptr), _gamma(1.0), _gamma_min(50), _gamma_max(120),
 	  _min_x1(INT_MAX), _max_x2(INT_MIN), _min_y1(INT_MAX), _max_y2(INT_MIN),
 
 	  _all_digits(true) {
@@ -169,7 +169,7 @@ bool MeterOCR::RecognizerTesseract::recognize(PIX *imageO, int dX, int dY, Reads
 	if (image_gs) {
 		pixDestroy(&image);
 		image = image_gs;
-		image_gs = 0;
+		image_gs = nullptr;
 		saveDebugImage(debugPixa, image, "grayscale");
 	}
 
@@ -186,20 +186,20 @@ bool MeterOCR::RecognizerTesseract::recognize(PIX *imageO, int dX, int dY, Reads
 	if (image_gs) {
 		pixDestroy(&image);
 		image = image_gs;
-		image_gs = 0;
+		image_gs = nullptr;
 		saveDebugImage(debugPixa, image, "unsharp");
 	}
 
 	// Normalize for uneven illumination on gray image
-	Pix *pixg = 0;
-	pixBackgroundNormGrayArrayMorph(image, NULL, 4, 5, 200, &pixg);
+	Pix *pixg = nullptr;
+	pixBackgroundNormGrayArrayMorph(image, nullptr, 4, 5, 200, &pixg);
 	image_gs = pixApplyInvBackgroundGrayMap(image, pixg, 4, 4);
 	pixDestroy(&pixg);
 
 	if (image_gs) {
 		pixDestroy(&image);
 		image = image_gs;
-		image_gs = 0;
+		image_gs = nullptr;
 		saveDebugImage(debugPixa, image, "normalize");
 	}
 
@@ -207,7 +207,7 @@ bool MeterOCR::RecognizerTesseract::recognize(PIX *imageO, int dX, int dY, Reads
 	if (image_gs) {
 		pixDestroy(&image);
 		image = image_gs;
-		image_gs = 0;
+		image_gs = nullptr;
 		saveDebugImage(debugPixa, image, "blockconv");
 	}
 
@@ -216,7 +216,7 @@ bool MeterOCR::RecognizerTesseract::recognize(PIX *imageO, int dX, int dY, Reads
 	if (image_gs) {
 		pixDestroy(&image);
 		image = image_gs;
-		image_gs = 0;
+		image_gs = nullptr;
 		saveDebugImage(debugPixa, image, "binary");
 	}
 
@@ -263,12 +263,12 @@ bool MeterOCR::RecognizerTesseract::recognize(PIX *imageO, int dX, int dY, Reads
 		BOX *box = boxCreate(left, top, w, h);
 		boxaAddBox(boxb, box, L_INSERT);
 
-		if (api->Recognize(0) == 0) {
+		if (api->Recognize(nullptr) == 0) {
 			std::string outtext;
 			tesseract::ResultIterator *ri = api->GetIterator();
 			tesseract::PageIteratorLevel level = tesseract::RIL_WORD;
 			double min_conf = DBL_MAX;
-			if (ri != 0) {
+			if (ri != nullptr) {
 				do {
 					const char *word = ri->GetUTF8Text(level);
 					float conf = ri->Confidence(level);
@@ -301,7 +301,8 @@ bool MeterOCR::RecognizerTesseract::recognize(PIX *imageO, int dX, int dY, Reads
 				readings[b.identifier].value = NAN;
 				readings[b.identifier].min_conf = 0;
 			} else {
-				readings[b.identifier].value += strtod(outtext.c_str(), NULL) * pow(10, b.scaler);
+				readings[b.identifier].value +=
+					strtod(outtext.c_str(), nullptr) * pow(10, b.scaler);
 				if (min_conf < readings[b.identifier].min_conf)
 					readings[b.identifier].min_conf = min_conf;
 				outtext.clear();
@@ -336,9 +337,9 @@ bool MeterOCR::RecognizerTesseract::initTesseract() {
 	// only for debugging:
 	api->SetVariable("tessedit_write_images", "T");
 
-	if (api->Init(NULL, "deu")) {
+	if (api->Init(nullptr, "deu")) {
 		delete api;
-		api = NULL;
+		api = nullptr;
 		print(log_error, "Could not init tesseract!", "RecognizerTesseract");
 		throw vz::VZException("could not init tesseract");
 	}
@@ -357,7 +358,7 @@ bool MeterOCR::RecognizerTesseract::deinitTesseract() {
 		return false;
 	api->End();
 	delete api;
-	api = 0;
+	api = nullptr;
 	return true;
 }
 

--- a/src/protocols/MeterOMS.cpp
+++ b/src/protocols/MeterOMS.cpp
@@ -135,13 +135,13 @@ MeterOMS::MeterOMS(const std::list<Option> &options, OMSHWif *hwif)
 
 	// init openssl:
 #if OPENSSL_VERSION_NUMBER >= 0x10100003L
-	OPENSSL_init_ssl(OPENSSL_INIT_LOAD_CONFIG, NULL);
+	OPENSSL_init_ssl(OPENSSL_INIT_LOAD_CONFIG, nullptr);
 	ERR_load_crypto_strings();
 	OpenSSL_add_all_algorithms(); // should be called after init
 #else
 	ERR_load_crypto_strings();
 	OpenSSL_add_all_algorithms();
-	OPENSSL_config(NULL);
+	OPENSSL_config(nullptr);
 #endif
 
 	// parse options:
@@ -500,7 +500,7 @@ bool MeterOMS::aes_decrypt(unsigned char *ciphertext, int ciphertext_len, unsign
 		return false;
 	}
 
-	if (!EVP_DecryptInit_ex(ctx, EVP_aes_128_cbc(), NULL, key, iv)) {
+	if (!EVP_DecryptInit_ex(ctx, EVP_aes_128_cbc(), nullptr, key, iv)) {
 		print(log_alert, "EVP_DecryptInit_ex failed", name().c_str());
 		EVP_CIPHER_CTX_free(ctx);
 		return false;

--- a/src/protocols/MeterRandom.cpp
+++ b/src/protocols/MeterRandom.cpp
@@ -68,7 +68,7 @@ MeterRandom::~MeterRandom() {}
 int MeterRandom::open() {
 
 	// TODO rewrite to use /dev/u?random
-	srand(time(NULL)); /* initialize PNRG */
+	srand(time(nullptr)); /* initialize PNRG */
 
 	return SUCCESS; /* can't fail */
 }

--- a/src/protocols/MeterS0.cpp
+++ b/src/protocols/MeterS0.cpp
@@ -297,7 +297,7 @@ void MeterS0::counter_thread() {
 				ts.tv_sec = 0;
 				ts.tv_nsec = nonblocking_delay_ns; // 5*(1e3) needed for up to 30kHz! 1e3 -> <1mhz,
 												   // 1e4 -> <100kHz, 1e5 -> <10kHz
-				nanosleep(&ts, NULL);              // we can ignore any errors here
+				nanosleep(&ts, nullptr);           // we can ignore any errors here
 			}
 		} // non blocking case
 	}     // while
@@ -364,7 +364,7 @@ ssize_t MeterS0::read(std::vector<Reading> &rds, size_t n) {
 	bool is_zero = true;
 	do {
 		req.tv_sec += 1;
-		CANCELLABLE(while (EINTR == clock_nanosleep(CLOCK_REALTIME, TIMER_ABSTIME, &req, NULL)));
+		CANCELLABLE(while (EINTR == clock_nanosleep(CLOCK_REALTIME, TIMER_ABSTIME, &req, nullptr)));
 		// check from counter_thread the current impulses:
 		t_imp = _impulses;
 		t_imp_neg = _impulses_neg;
@@ -541,7 +541,7 @@ bool MeterS0::HWIF_UART::waitForImpulse(bool &timeout) {
 #define BCM2708_PERI_BASE_RPI2 0x3F000000
 
 MeterS0::HWIF_MMAP::HWIF_MMAP(int gpiopin, const std::string &hw)
-	: _gpiopin(gpiopin), _gpio(0), _gpio_base(0) {
+	: _gpiopin(gpiopin), _gpio(nullptr), _gpio_base(nullptr) {
 	// check gpiopin for max value! (todo)
 	// we do mmap in _open only
 	if (hw == "rpi" || hw == "rpi1")
@@ -564,7 +564,7 @@ bool MeterS0::HWIF_MMAP::_open() {
 		return false;
 	}
 
-	void *gpio_map = mmap((void *)NULL,           // Any adddress in our space will do
+	void *gpio_map = mmap(nullptr,                // Any adddress in our space will do
 						  BLOCK_SIZE,             // Map length
 						  PROT_READ | PROT_WRITE, // Enable reading & writting to mapped memory
 						  MAP_SHARED,             // Shared with other processes
@@ -587,7 +587,7 @@ bool MeterS0::HWIF_MMAP::_open() {
 
 bool MeterS0::HWIF_MMAP::_close() {
 	// need unmap? todo
-	_gpio = 0;
+	_gpio = nullptr;
 	return true;
 }
 

--- a/src/protocols/MeterSML.cpp
+++ b/src/protocols/MeterSML.cpp
@@ -85,7 +85,7 @@ MeterSML::MeterSML(std::list<Option> options)
 			char hs[3];
 			strncpy(hs, hex.c_str() + i, 2);
 			char hx[2];
-			hx[0] = strtol(hs, NULL, 16);
+			hx[0] = strtol(hs, nullptr, 16);
 			_pull.append(hx, 1);
 		}
 		print(log_debug, "pullseq len:%d found", name().c_str(), _pull.size());
@@ -208,7 +208,7 @@ int MeterSML::open() {
 		char *addr = strdup(host());
 		const char *node = strsep(&addr, ":");
 		const char *service = strsep(&addr, ":");
-		if (node == NULL && service == NULL) {
+		if (node == nullptr && service == nullptr) {
 			free(addr);
 			return -1;
 		}
@@ -290,7 +290,7 @@ ssize_t MeterSML::read(std::vector<Reading> &rds, size_t n) {
 			entry = body->val_list;
 
 			/* iterating through linked list */
-			for (; m < n && entry != NULL;) {
+			for (; m < n && entry != nullptr;) {
 				if (_parse(entry, &rds[m]))
 					m++;
 				entry = entry->next;
@@ -311,7 +311,7 @@ bool MeterSML::_parse(sml_list *entry, Reading *rd) {
 	Obis obis((unsigned char)entry->obj_name->str[0], (unsigned char)entry->obj_name->str[1],
 			  (unsigned char)entry->obj_name->str[2], (unsigned char)entry->obj_name->str[3],
 			  (unsigned char)entry->obj_name->str[4], (unsigned char)entry->obj_name->str[5]);
-	if (obis.isValid() && entry->value != NULL) {
+	if (obis.isValid() && entry->value != nullptr) {
 		// some entries might contain a string so check type and use proper rd->value(...) call
 		// if the entry does contain a string we can either throw it away or try to convert it to
 		// a value. We throw it away for now as its octet encoded and would need some conversion
@@ -332,7 +332,7 @@ bool MeterSML::_parse(sml_list *entry, Reading *rd) {
 			tv.tv_sec = *entry->val_time->data.timestamp;
 			tv.tv_usec = 0;
 		} else {
-			gettimeofday(&tv, NULL); /* use local time */
+			gettimeofday(&tv, nullptr); /* use local time */
 		}
 		rd->time(tv);
 		return true;
@@ -351,7 +351,7 @@ int MeterSML::_openSocket(const char *node, const char *service) {
 		return ERR;
 	}
 
-	int rc = getaddrinfo(node, service, NULL, &ais);
+	int rc = getaddrinfo(node, service, nullptr, &ais);
 	if (rc != 0) {
 		print(log_alert, "getaddrinfo(%s, %s): %s", name().c_str(), node, service,
 			  gai_strerror(rc));

--- a/src/protocols/MeterW1therm.cpp
+++ b/src/protocols/MeterW1therm.cpp
@@ -39,13 +39,13 @@ bool MeterW1therm::W1sysHWif::scanW1devices() {
 				  "?"
 				  "?"
 				  "-*",
-				  GLOB_NOSORT, NULL, &glob_res)) {
+				  GLOB_NOSORT, nullptr, &glob_res)) {
 
 		// 1wire ID prefixes of supported sensors
-		const char *ids[] = {"10", "22", "28", "3b", "42", NULL};
+		const char *ids[] = {"10", "22", "28", "3b", "42", nullptr};
 
 		for (unsigned int i = 0; i < glob_res.gl_pathc; ++i) {
-			for (unsigned int j = 0; ids[j] != NULL; j++) {
+			for (unsigned int j = 0; ids[j] != nullptr; j++) {
 				if (strlen(glob_res.gl_pathv[i]) > strl &&
 					!strncmp(glob_res.gl_pathv[i] + strl, ids[j], 2)) {
 					char *str = glob_res.gl_pathv[i] + strl;
@@ -71,7 +71,7 @@ bool MeterW1therm::W1sysHWif::readTemp(const std::string &device, double &value)
 	dev.append("/w1_slave");
 
 	FILE *fp;
-	if ((fp = fopen(dev.c_str(), "r")) == NULL) {
+	if ((fp = fopen(dev.c_str(), "r")) == nullptr) {
 		print(log_debug, "couldn't open %s for reading", "w1t", dev.c_str());
 		return false;
 	}

--- a/src/test.cpp
+++ b/src/test.cpp
@@ -34,7 +34,7 @@ void test_buffer() {
 	struct timeval tv;
 	StringIdentifier id;
 
-	gettimeofday(&tv, NULL);
+	gettimeofday(&tv, nullptr);
 
 	for (int i = 0; i < 10; i++) {
 		Reading rd;

--- a/src/threads.cpp
+++ b/src/threads.cpp
@@ -53,8 +53,8 @@ void *reading_thread(void *arg) {
 	bool first_reading = true;
 
 	// Only allow cancellation at safe points
-	pthread_setcancelstate(PTHREAD_CANCEL_DISABLE, NULL);
-	pthread_setcanceltype(PTHREAD_CANCEL_DEFERRED, NULL);
+	pthread_setcancelstate(PTHREAD_CANCEL_DISABLE, nullptr);
+	pthread_setcanceltype(PTHREAD_CANCEL_DEFERRED, nullptr);
 
 	details = meter_get_details(mtr->protocolId());
 	std::vector<Reading> rds(details->max_readings, Reading(mtr->identifier()));
@@ -63,12 +63,12 @@ void *reading_thread(void *arg) {
 	print(log_debug, "Config.local: %d", mtr->name(), options.local());
 
 	try {
-		aggIntEnd = time(NULL);
+		aggIntEnd = time(nullptr);
 		do { /* start thread main loop */
 			_safe_to_cancel();
 			do {
 				aggIntEnd += mtr->aggtime(); /* end of this aggregation period */
-			} while ((aggIntEnd < time(NULL)) && (mtr->aggtime() > 0));
+			} while ((aggIntEnd < time(nullptr)) && (mtr->aggtime() > 0));
 			do { /* aggregate loop */
 				_safe_to_cancel();
 				int interval = mtr->interval();
@@ -148,8 +148,9 @@ void *reading_thread(void *arg) {
 							}
 						}
 
-					}                                                   // channel loop
-			} while ((mtr->aggtime() > 0) && (time(NULL) < aggIntEnd)); /* default aggtime is -1 */
+					} // channel loop
+			} while ((mtr->aggtime() > 0) &&
+					 (time(nullptr) < aggIntEnd)); /* default aggtime is -1 */
 
 			for (MeterMap::iterator ch = mapping->begin(); ch != mapping->end(); ch++) {
 
@@ -199,13 +200,13 @@ void *reading_thread(void *arg) {
 		std::stringstream oss;
 		oss << e.what();
 		print(log_alert, "Reading-THREAD - reading got an exception : %s", mtr->name(), e.what());
-		pthread_exit(0);
+		pthread_exit(nullptr);
 	}
 
 	print(log_debug, "Stopped reading. ", mtr->name());
 
-	pthread_exit(0);
-	return NULL;
+	pthread_exit(nullptr);
+	return nullptr;
 }
 
 void *logging_thread(void *arg) { // is started by Channel::start and stopped via
@@ -251,7 +252,7 @@ void *logging_thread(void *arg) { // is started by Channel::start and stopped vi
 	} while (true); // endless?!
 
 	print(log_debug, "Stopped logging.", ch->name());
-	pthread_exit(0);
+	pthread_exit(nullptr);
 
-	return NULL;
+	return nullptr;
 }

--- a/src/vzlogger.cpp
+++ b/src/vzlogger.cpp
@@ -66,7 +66,7 @@ MapContainer mappings;     // mapping between meters and channels
 Config_Options options;    // global application options
 size_t gSkippedFailed = 0; // disabled or failed meters
 
-std::stringbuf *gStartLogBuf = 0; // temporay buffer for print until logfile is opened
+std::stringbuf *gStartLogBuf = nullptr; // temporay buffer for print until logfile is opened
 std::mutex
 	m_log; // mutex for central log function, to prevent competed write access from the threads.
 
@@ -74,18 +74,18 @@ std::mutex
  * Command line options
  */
 const struct option long_options[] = {
-	{"config", required_argument, 0, 'c'},
-	{"log", required_argument, 0, 'o'},
-	{"foreground", no_argument, 0, 'f'},
+	{"config", required_argument, nullptr, 'c'},
+	{"log", required_argument, nullptr, 'o'},
+	{"foreground", no_argument, nullptr, 'f'},
 #ifdef LOCAL_SUPPORT
-	{"httpd", no_argument, 0, 'l'},
-	{"httpd-port", required_argument, 0, 'p'},
+	{"httpd", no_argument, nullptr, 'l'},
+	{"httpd-port", required_argument, nullptr, 'p'},
 #endif /* LOCAL_SUPPORT */
-	{"register", no_argument, 0, 'r'},
-	{"verbose", required_argument, 0, 'v'},
-	{"help", no_argument, 0, 'h'},
-	{"version", no_argument, 0, 'V'},
-	{0, 0, 0, 0} /* stop condition for iterator */
+	{"register", no_argument, nullptr, 'r'},
+	{"verbose", required_argument, nullptr, 'v'},
+	{"help", no_argument, nullptr, 'h'},
+	{"version", no_argument, nullptr, 'V'},
+	{nullptr, 0, nullptr, 0} /* stop condition for iterator */
 };
 
 /**
@@ -103,14 +103,14 @@ const char *long_options_descs[] = {
 	"enable verbose output",
 	"show this help",
 	"show version of vzlogger",
-	NULL /* stop condition for iterator */
+	nullptr /* stop condition for iterator */
 };
 
 void openLogfile(bool skip_lock = false) {
 	FILE *logfd = fopen(options.log().c_str(), "a");
 
-	if (logfd == NULL) {
-		print(log_alert, "opening logfile \"%s\" failed: %s", (char *)0, options.log().c_str(),
+	if (logfd == nullptr) {
+		print(log_alert, "opening logfile \"%s\" failed: %s", nullptr, options.log().c_str(),
 			  strerror(errno));
 		exit(EX_CANTCREAT);
 	}
@@ -122,14 +122,14 @@ void openLogfile(bool skip_lock = false) {
 		// log current console output to logfile as we missed the start
 		fprintf(logfd, "%s", gStartLogBuf->str().c_str());
 		auto temp = gStartLogBuf;
-		gStartLogBuf = 0;
+		gStartLogBuf = nullptr;
 		delete temp;
 	}
 
 	options.logfd(logfd);
 	if (!skip_lock)
 		m_log.unlock();
-	print(log_debug, "Opened logfile %s", (char *)0, options.log().c_str());
+	print(log_debug, "Opened logfile %s", nullptr, options.log().c_str());
 }
 
 void closeLogfile(bool skip_lock = false) {
@@ -137,7 +137,7 @@ void closeLogfile(bool skip_lock = false) {
 		m_log.lock();
 	if (options.logfd()) {
 		fclose(options.logfd());
-		options.logfd(NULL);
+		options.logfd(nullptr);
 	}
 	if (!skip_lock)
 		m_log.unlock();
@@ -146,7 +146,7 @@ void closeLogfile(bool skip_lock = false) {
 /**
  * Print error/debug/info messages to stdout and/or logfile
  *
- * @param id could be NULL for general messages
+ * @param id could be nullptr for general messages
  * @todo integrate into syslog
  */
 void print(log_level_t level, const char *format, const char *id, ...) {
@@ -159,7 +159,7 @@ void print(log_level_t level, const char *format, const char *id, ...) {
 	char prefix[24];
 	size_t pos = 0;
 
-	gettimeofday(&now, NULL);
+	gettimeofday(&now, nullptr);
 	timeinfo = localtime(&now.tv_sec);
 
 	/* format timestamp */
@@ -234,7 +234,7 @@ void show_usage(char *argv[]) {
 	/* obis aliases */
 	printf("\n  following OBIS aliases are available:\n");
 	char obis_str[OBIS_STR_LEN];
-	for (obis_alias_t *it = obis_get_aliases(); it->name != NULL; it++) {
+	for (obis_alias_t *it = obis_get_aliases(); it->name != nullptr; it++) {
 		it->id.unparse(obis_str, OBIS_STR_LEN);
 		printf("\t%-17s%-31s%-22s\n", it->name, it->desc, obis_str);
 	}
@@ -290,10 +290,10 @@ void daemonize() {
 	action.sa_flags = 0;
 	action.sa_handler = SIG_IGN;
 
-	sigaction(SIGCHLD, &action, NULL); /* ignore child */
-	sigaction(SIGTSTP, &action, NULL); /* ignore tty signals */
-	sigaction(SIGTTOU, &action, NULL);
-	sigaction(SIGTTIN, &action, NULL);
+	sigaction(SIGCHLD, &action, nullptr); /* ignore child */
+	sigaction(SIGTSTP, &action, nullptr); /* ignore tty signals */
+	sigaction(SIGTTOU, &action, nullptr);
+	sigaction(SIGTTIN, &action, nullptr);
 }
 
 /**
@@ -335,7 +335,7 @@ void signalHandlerReOpenLog(int) { mainLoopReopenLogfile = true; }
  */
 int config_parse_cli(int argc, char *argv[], Config_Options *options) {
 	while (1) {
-		int c = getopt_long(argc, argv, "c:o:p:lhrVfv:", long_options, NULL);
+		int c = getopt_long(argc, argv, "c:o:p:lhrVfv:", long_options, nullptr);
 
 		/* detect the end of the options. */
 		if (c == -1)
@@ -427,9 +427,9 @@ int main(int argc, char *argv[]) {
 	sigemptyset(&quitaction.sa_mask);
 	quitaction.sa_flags = 0;
 	quitaction.sa_handler = signalHandlerQuit;
-	sigaction(SIGINT, &quitaction, NULL);  /* catch ctrl-c from terminal */
-	sigaction(SIGHUP, &quitaction, NULL);  /* catch hangup signal */
-	sigaction(SIGTERM, &quitaction, NULL); /* catch kill signal */
+	sigaction(SIGINT, &quitaction, nullptr);  /* catch ctrl-c from terminal */
+	sigaction(SIGHUP, &quitaction, nullptr);  /* catch hangup signal */
+	sigaction(SIGTERM, &quitaction, nullptr); /* catch kill signal */
 
 	// signal for re-opening logfile
 	struct sigaction reopenaction;
@@ -442,7 +442,7 @@ int main(int argc, char *argv[]) {
 
 #ifdef LOCAL_SUPPORT
 	/* webserver for local interface */
-	struct MHD_Daemon *httpd_handle = NULL;
+	struct MHD_Daemon *httpd_handle = nullptr;
 #endif /* LOCAL_SUPPORT */
 
 	/* initialize ADTs and APIs */
@@ -464,7 +464,7 @@ int main(int argc, char *argv[]) {
 	} catch (std::exception &e) {
 		std::stringstream oss;
 		oss << e.what();
-		print(log_alert, "Failed to parse configuration due to: %s", NULL, oss.str().c_str());
+		print(log_alert, "Failed to parse configuration due to: %s", nullptr, oss.str().c_str());
 		return EX_CONFIG;
 	}
 
@@ -485,31 +485,31 @@ int main(int argc, char *argv[]) {
 	print(log_debug, "local=%d", "main", options.local());
 
 	if (!options.foreground()) {
-		print(log_info, "Daemonize process...", (char *)0);
+		print(log_info, "Daemonize process...", nullptr);
 		daemonize();
 	} else {
-		print(log_info, "Process not daemonized...", (char *)0);
+		print(log_info, "Process not daemonized...", nullptr);
 	}
 
 	/* open logfile */
 	if (options.log() != "") {
 		openLogfile();
-		sigaction(SIGUSR1, &reopenaction, NULL); // catch SIGUSR1
+		sigaction(SIGUSR1, &reopenaction, nullptr); // catch SIGUSR1
 	} else {
 		// stop temp logging, continue logging to console only
 		auto temp = gStartLogBuf;
-		gStartLogBuf = 0;
+		gStartLogBuf = nullptr;
 		delete temp;
 	}
 
 	if (mappings.size() <= 0) {
-		print(log_alert, "No meters found - quitting!", (char *)0);
+		print(log_alert, "No meters found - quitting!", nullptr);
 		return EXIT_FAILURE;
 	}
 
 	if (options.pushDataServer()) {
 		pushDataList = new PushDataList();
-		int ret = pthread_create(&_pushdata_thread, NULL, push_data_thread,
+		int ret = pthread_create(&_pushdata_thread, nullptr, push_data_thread,
 								 (void *)options.pushDataServer()); // todo error handling?
 		if (ret)
 			print(log_error, "Error %d creating pushdata_thread!", "push", ret);
@@ -521,7 +521,7 @@ int main(int argc, char *argv[]) {
 
 #ifdef ENABLE_MQTT
 	if (mqttClient) {
-		int ret = pthread_create(&_mqtt_client_thread, NULL, mqtt_client_thread, (void *)0);
+		int ret = pthread_create(&_mqtt_client_thread, nullptr, mqtt_client_thread, nullptr);
 		if (ret)
 			print(log_error, "Error %d creating mqtt_client_thread!", "mqtt", ret);
 		else
@@ -541,7 +541,7 @@ int main(int argc, char *argv[]) {
 
 		// quit if not at least one meter is enabled and working
 		if (mappings.size() - gSkippedFailed <= 0) {
-			print(log_alert, "No functional meters found - quitting!", (char *)0);
+			print(log_alert, "No functional meters found - quitting!", nullptr);
 			return EXIT_FAILURE;
 		}
 
@@ -550,7 +550,7 @@ int main(int argc, char *argv[]) {
 		if (options.local()) {
 			print(log_info, "Starting local interface HTTPd on port %i", "http", options.port());
 			httpd_handle =
-				MHD_start_daemon(MHD_USE_THREAD_PER_CONNECTION, options.port(), NULL, NULL,
+				MHD_start_daemon(MHD_USE_THREAD_PER_CONNECTION, options.port(), nullptr, nullptr,
 								 &handle_request, (void *)&mappings, MHD_OPTION_END);
 		}
 #endif /* LOCAL_SUPPORT */
@@ -621,12 +621,12 @@ int main(int argc, char *argv[]) {
 
 		end_push_data_thread();
 		print(log_finest, "Waiting for pushdata_thread to stop...", "");
-		pthread_join(_pushdata_thread, NULL);
+		pthread_join(_pushdata_thread, nullptr);
 		print(log_finest, "pushdata_thread stopped", "");
 
 		if (pushDataList) {
 			delete pushDataList;
-			pushDataList = 0;
+			pushDataList = nullptr;
 			print(log_finest, "deleted pushdataList", "");
 		}
 	}
@@ -635,12 +635,12 @@ int main(int argc, char *argv[]) {
 	if (_mqtt_client_thread) {
 		end_mqtt_client_thread();
 		print(log_finest, "Waiting for mqtt_client_thread to stop...", "mqtt");
-		pthread_join(_mqtt_client_thread, NULL);
+		pthread_join(_mqtt_client_thread, nullptr);
 		print(log_finest, "mqtt_client_thread stopped", "mqtt");
 	}
 	if (mqttClient) {
 		delete mqttClient;
-		mqttClient = 0;
+		mqttClient = nullptr;
 		print(log_finest, "deleted mqttClient", "mqtt");
 	}
 #endif
@@ -648,7 +648,7 @@ int main(int argc, char *argv[]) {
 	if (curlSessionProvider) {
 		print(log_finest, "Trying to delete curlSessionProvider...", "");
 		delete curlSessionProvider;
-		curlSessionProvider = 0;
+		curlSessionProvider = nullptr;
 		print(log_finest, "deleted curlSessionProvider", "");
 	}
 

--- a/tests/MeterD0.cpp
+++ b/tests/MeterD0.cpp
@@ -25,7 +25,7 @@ void print(log_level_t l, char const *s1, char const *s2, ...) {
 }
 
 int writes(int fd, const char *str) {
-	EXPECT_NE((char *)0, str);
+	EXPECT_NE(nullptr, str);
 	int len = strlen(str);
 	return write(fd, str, len);
 }
@@ -34,7 +34,7 @@ TEST(MeterD0, basic_dump_fd) {
 
 	std::string dumpName("/tmp/dumpD0UnitTestxyz1234");
 	char tempfilename[L_tmpnam + 1];
-	ASSERT_NE(tmpnam(tempfilename), (char *)0);
+	ASSERT_NE(tmpnam(tempfilename), nullptr);
 	ASSERT_NE(strlen(tempfilename), 0ul);
 	std::list<Option> options;
 	options.push_back(Option("device", tempfilename));
@@ -67,7 +67,7 @@ TEST(MeterD0, basic_dump_fd_autoack) {
 
 	std::string dumpName("/tmp/dumpD0UnitTestxyz1234");
 	char tempfilename[L_tmpnam + 1];
-	ASSERT_NE(tmpnam(tempfilename), (char *)0);
+	ASSERT_NE(tmpnam(tempfilename), nullptr);
 	std::list<Option> options;
 	options.push_back(Option("device", tempfilename));
 	options.push_back(Option("dump_file", (char *)dumpName.c_str()));
@@ -101,7 +101,7 @@ TEST(MeterD0, basic_dump_fd_autoack) {
 
 TEST(MeterD0, HagerEHZ_basic) {
 	char tempfilename[L_tmpnam + 1];
-	ASSERT_NE(tmpnam(tempfilename), (char *)0);
+	ASSERT_NE(tmpnam(tempfilename), nullptr);
 	std::list<Option> options;
 	options.push_back(Option("device", tempfilename));
 	MeterD0 m(options);
@@ -131,18 +131,18 @@ TEST(MeterD0, HagerEHZ_basic) {
 	double value = rds[0].value();
 	EXPECT_EQ(1.2963, value);
 	ObisIdentifier *o = dynamic_cast<ObisIdentifier *>(p);
-	ASSERT_NE((ObisIdentifier *)0, o);
+	ASSERT_NE(nullptr, o);
 	EXPECT_TRUE(Obis(1, 0, 1, 8, 0, 255) == (o->obis()));
 
 	EXPECT_EQ(2, m.read(rds, 2));
 	o = dynamic_cast<ObisIdentifier *>(rds[0].identifier().get());
-	ASSERT_NE((ObisIdentifier *)0, o);
+	ASSERT_NE(nullptr, o);
 	value = rds[0].value();
 	EXPECT_EQ(1.2964, value);
 	EXPECT_TRUE(Obis(1, 0, 1, 7, 0, 255) == (o->obis()));
 
 	o = dynamic_cast<ObisIdentifier *>(rds[1].identifier().get());
-	ASSERT_NE((ObisIdentifier *)0, o);
+	ASSERT_NE(nullptr, o);
 	value = rds[1].value();
 	EXPECT_EQ(1.2965, value);
 	EXPECT_TRUE(Obis(1, 0, 1, 9, 0, 255) == (o->obis()));
@@ -156,7 +156,7 @@ TEST(MeterD0, HagerEHZ_basic) {
 TEST(MeterD0, HagerEHZ_waitsync) {
 	char tempfilename[L_tmpnam + 1];
 	char strend[5] = "end\0";
-	ASSERT_NE(tmpnam(tempfilename), (char *)0);
+	ASSERT_NE(tmpnam(tempfilename), nullptr);
 	std::list<Option> options;
 	options.push_back(Option("device", tempfilename));
 	options.push_back(Option("wait_sync", strend));
@@ -186,7 +186,7 @@ TEST(MeterD0, HagerEHZ_waitsync) {
 	double value = rds[0].value();
 	EXPECT_EQ(999999.9999, value);
 	ObisIdentifier *o = dynamic_cast<ObisIdentifier *>(p);
-	ASSERT_NE((ObisIdentifier *)0, o);
+	ASSERT_NE(nullptr, o);
 	EXPECT_TRUE(Obis(2, 1, 2, 3, 4, 255) == (o->obis()));
 
 	EXPECT_EQ(0, m.close());
@@ -198,7 +198,7 @@ TEST(MeterD0, HagerEHZ_waitsync) {
 TEST(MeterD0, LandisGyr_basic) {
 	char tempfilename[L_tmpnam + 1];
 	char str_pullseq[12] = "2f3f210d0a";
-	ASSERT_NE(tmpnam(tempfilename), (char *)0);
+	ASSERT_NE(tmpnam(tempfilename), nullptr);
 	std::list<Option> options;
 	options.push_back(Option("device", tempfilename));
 	options.push_back(Option("pullseq", str_pullseq));
@@ -255,17 +255,17 @@ TEST(MeterD0, LandisGyr_basic) {
 	double value = rds[2].value();
 	EXPECT_EQ(1846.0, value);
 	ObisIdentifier *o = dynamic_cast<ObisIdentifier *>(p);
-	ASSERT_NE((ObisIdentifier *)0, o);
+	ASSERT_NE(nullptr, o);
 	EXPECT_TRUE(Obis(0xff, 0xff, 1, 8, 1, 255) == (o->obis()));
 
 	o = dynamic_cast<ObisIdentifier *>(rds[3].identifier().get());
-	ASSERT_NE((ObisIdentifier *)0, o);
+	ASSERT_NE(nullptr, o);
 	value = rds[3].value();
 	EXPECT_EQ(0.0, value);
 	EXPECT_TRUE(Obis(0xff, 0xff, 1, 8, 2, 0xff) == (o->obis()));
 
 	o = dynamic_cast<ObisIdentifier *>(rds[4].identifier().get());
-	ASSERT_NE((ObisIdentifier *)0, o);
+	ASSERT_NE(nullptr, o);
 	value = rds[4].value();
 	EXPECT_EQ(4329.6, value);
 	EXPECT_TRUE(Obis(0xff, 0xff, 2, 8, 1, 0xff) == (o->obis()));
@@ -295,7 +295,7 @@ int writes_hex(int fd, const char *str) {
 TEST(MeterD0, ACE3000_basic) {
 	char tempfilename[L_tmpnam + 1];
 	char str_pullseq[12] = "2f3f210d0a";
-	ASSERT_NE(tmpnam(tempfilename), (char *)0);
+	ASSERT_NE(tmpnam(tempfilename), nullptr);
 	std::list<Option> options;
 	options.push_back(Option("device", tempfilename));
 	options.push_back(Option("pullseq", str_pullseq));
@@ -347,17 +347,17 @@ TEST(MeterD0, ACE3000_basic) {
 	double value = rds[3].value();
 	EXPECT_EQ(13925.5, value);
 	ObisIdentifier *o = dynamic_cast<ObisIdentifier *>(p);
-	ASSERT_NE((ObisIdentifier *)0, o);
+	ASSERT_NE(nullptr, o);
 	EXPECT_TRUE(Obis(0xff, 0xff, 1, 8, 0, 255) == (o->obis()));
 
 	o = dynamic_cast<ObisIdentifier *>(rds[1].identifier().get());
-	ASSERT_NE((ObisIdentifier *)0, o);
+	ASSERT_NE(nullptr, o);
 	value = rds[1].value();
 	EXPECT_EQ(1126120053322353.0, value);
 	EXPECT_TRUE(Obis(0xff, 0xff, 96, 1, 0xff, 0xff) == (o->obis()));
 
 	o = dynamic_cast<ObisIdentifier *>(rds[0].identifier().get());
-	ASSERT_NE((ObisIdentifier *)0, o);
+	ASSERT_NE(nullptr, o);
 	value = rds[0].value();
 	EXPECT_EQ(0.0, value);
 	EXPECT_TRUE(Obis(0xff, 0xff, 97, 97, 0xff, 0xff) == (o->obis()));
@@ -406,7 +406,7 @@ baudrate=4, identification=\@DC341TMPBF2ZAK) [Dec 23 11:59:11][d0]   Sending ack
 
 TEST(MeterD0, LuG_E350) {
 	char tempfilename[L_tmpnam + 1];
-	ASSERT_NE(tmpnam(tempfilename), (char *)0);
+	ASSERT_NE(tmpnam(tempfilename), nullptr);
 	std::list<Option> options;
 	options.push_back(Option("device", tempfilename));
 	MeterD0 m(options);
@@ -460,7 +460,7 @@ TEST(MeterD0, LuG_E350) {
 	double value = rds[22].value();
 	EXPECT_EQ(1420.0, value);
 	ObisIdentifier *o = dynamic_cast<ObisIdentifier *>(p);
-	ASSERT_NE((ObisIdentifier *)0, o);
+	ASSERT_NE(nullptr, o);
 	EXPECT_TRUE(Obis("C.5.0") == (o->obis()));
 
 	EXPECT_EQ(0, m.close());

--- a/tests/MeterSML.cpp
+++ b/tests/MeterSML.cpp
@@ -12,7 +12,7 @@ TEST(MeterSML, EMH_basic) {
 	using std::fabs;
 
 	char tempfilename[L_tmpnam + 1];
-	ASSERT_NE(tmpnam(tempfilename), (char *)0);
+	ASSERT_NE(tmpnam(tempfilename), nullptr);
 	std::list<Option> options;
 	options.push_back(Option("device", tempfilename));
 	MeterSML m(options);
@@ -141,17 +141,17 @@ TEST(MeterSML, EMH_basic) {
 	double value = rds[0].value();
 	EXPECT_LE(fabs(14796777.1 - value), 0.1);
 	ObisIdentifier *o = dynamic_cast<ObisIdentifier *>(p);
-	ASSERT_NE((ObisIdentifier *)0, o);
+	ASSERT_NE(nullptr, o);
 	EXPECT_TRUE(Obis(1, 0, 1, 8, 1, 255) == (o->obis()));
 
 	o = dynamic_cast<ObisIdentifier *>(rds[1].identifier().get());
-	ASSERT_NE((ObisIdentifier *)0, o);
+	ASSERT_NE(nullptr, o);
 	value = rds[1].value();
 	EXPECT_EQ(2012.4, value);
 	EXPECT_TRUE(Obis(1, 0, 1, 8, 2, 255) == (o->obis()));
 
 	o = dynamic_cast<ObisIdentifier *>(rds[2].identifier().get());
-	ASSERT_NE((ObisIdentifier *)0, o);
+	ASSERT_NE(nullptr, o);
 	value = rds[2].value();
 	EXPECT_LE(fabs(11.2 - value), 0.1);
 	EXPECT_TRUE(Obis(1, 0, 1, 7, 0, 255) == (o->obis()));

--- a/tests/ut_CurlSessionProvider.cpp
+++ b/tests/ut_CurlSessionProvider.cpp
@@ -3,11 +3,11 @@
 #include "CurlSessionProvider.hpp"
 
 TEST(CurlSessionProvider, init) {
-	ASSERT_EQ(0, curlSessionProvider);
+	ASSERT_EQ(nullptr, curlSessionProvider);
 	curlSessionProvider = new CurlSessionProvider();
 
 	delete curlSessionProvider;
-	curlSessionProvider = 0;
+	curlSessionProvider = nullptr;
 }
 
 TEST(CurlSessionProvider, single1) {
@@ -16,22 +16,22 @@ TEST(CurlSessionProvider, single1) {
 	ASSERT_FALSE(curlSessionProvider->inUse("1"));
 
 	CURL *eh = curlSessionProvider->get_easy_session("1");
-	ASSERT_TRUE(0 != eh);
+	ASSERT_TRUE(nullptr != eh);
 	ASSERT_TRUE(curlSessionProvider->inUse("1"));
 	curlSessionProvider->return_session("1", eh);
-	ASSERT_EQ(0, eh);
+	ASSERT_EQ(nullptr, eh);
 	ASSERT_FALSE(curlSessionProvider->inUse("1"));
 
 	// 2nd try:
 	eh = curlSessionProvider->get_easy_session("1");
-	ASSERT_TRUE(0 != eh);
+	ASSERT_TRUE(nullptr != eh);
 	ASSERT_TRUE(curlSessionProvider->inUse("1"));
 	curlSessionProvider->return_session("1", eh);
-	ASSERT_EQ(0, eh);
+	ASSERT_EQ(nullptr, eh);
 	ASSERT_FALSE(curlSessionProvider->inUse("1"));
 
 	delete curlSessionProvider;
-	curlSessionProvider = 0;
+	curlSessionProvider = nullptr;
 
 	// TODO create that that's spanws a thread and tests blocking on a shared session
 }

--- a/tests/ut_MeterExec.cpp
+++ b/tests/ut_MeterExec.cpp
@@ -18,7 +18,7 @@ int writes(int fd, const char *str);
 
 TEST(MeterExec, basic) {
 	char tempfilename[L_tmpnam + 1];
-	ASSERT_NE(tmpnam(tempfilename), (char *)0);
+	ASSERT_NE(tmpnam(tempfilename), nullptr);
 	std::list<Option> options;
 	options.push_back(Option("command", tempfilename));
 
@@ -31,7 +31,7 @@ TEST(MeterExec, basic) {
 
 TEST(MeterExec, format1) {
 	char tempfilename[L_tmpnam + 1];
-	ASSERT_NE(tmpnam(tempfilename), (char *)0);
+	ASSERT_NE(tmpnam(tempfilename), nullptr);
 	std::list<Option> options;
 	options.push_back(Option("command", tempfilename));
 	options.push_back(Option("format", (char *)"$v"));
@@ -43,7 +43,7 @@ TEST(MeterExec, format1) {
 
 TEST(MeterExec, format2) {
 	char tempfilename[L_tmpnam + 1];
-	ASSERT_NE(tmpnam(tempfilename), (char *)0);
+	ASSERT_NE(tmpnam(tempfilename), nullptr);
 	std::list<Option> options;
 	options.push_back(Option("command", tempfilename));
 	options.push_back(Option("format", (char *)"$i : $v"));
@@ -55,7 +55,7 @@ TEST(MeterExec, format2) {
 
 TEST(MeterExec, format3) {
 	char tempfilename[L_tmpnam + 1];
-	ASSERT_NE(tmpnam(tempfilename), (char *)0);
+	ASSERT_NE(tmpnam(tempfilename), nullptr);
 	std::list<Option> options;
 	options.push_back(Option("command", tempfilename));
 	options.push_back(Option("format", (char *)"$t;$i : $v"));

--- a/tests/ut_MeterFile.cpp
+++ b/tests/ut_MeterFile.cpp
@@ -18,7 +18,7 @@ int writes(int fd, const char *str);
 
 TEST(MeterFile, basic) {
 	char tempfilename[L_tmpnam + 1];
-	ASSERT_NE(tmpnam(tempfilename), (char *)0);
+	ASSERT_NE(tmpnam(tempfilename), nullptr);
 	std::list<Option> options;
 	options.push_back(Option("path", tempfilename));
 	options.push_back(Option("interval", 1));
@@ -48,14 +48,14 @@ TEST(MeterFile, basic) {
 	double value = rds[0].value();
 	EXPECT_EQ(32552, value);
 	StringIdentifier *o = dynamic_cast<StringIdentifier *>(p);
-	ASSERT_NE((StringIdentifier *)0, o);
+	ASSERT_NE(nullptr, o);
 	EXPECT_EQ(StringIdentifier(""), *o);
 
 	value = rds[1].value();
 	p = rds[1].identifier().get();
 	o = dynamic_cast<StringIdentifier *>(p);
 	EXPECT_EQ(32552.5, value);
-	ASSERT_NE((StringIdentifier *)0, o);
+	ASSERT_NE(nullptr, o);
 	EXPECT_EQ(StringIdentifier(""), *o);
 
 	EXPECT_EQ(0, m.close());
@@ -66,7 +66,7 @@ TEST(MeterFile, basic) {
 
 TEST(MeterFile, format1) {
 	char tempfilename[L_tmpnam + 1];
-	ASSERT_NE(tmpnam(tempfilename), (char *)0);
+	ASSERT_NE(tmpnam(tempfilename), nullptr);
 	std::list<Option> options;
 	options.push_back(Option("path", tempfilename));
 	options.push_back(Option("format", (char *)"$v"));
@@ -94,14 +94,14 @@ TEST(MeterFile, format1) {
 	double value = rds[0].value();
 	EXPECT_EQ(32552, value);
 	StringIdentifier *o = dynamic_cast<StringIdentifier *>(p);
-	ASSERT_NE((StringIdentifier *)0, o);
+	ASSERT_NE(nullptr, o);
 	EXPECT_EQ(StringIdentifier("<null>"), *o);
 
 	value = rds[1].value();
 	p = rds[1].identifier().get();
 	o = dynamic_cast<StringIdentifier *>(p);
 	EXPECT_EQ(32552.5, value);
-	ASSERT_NE((StringIdentifier *)0, o);
+	ASSERT_NE(nullptr, o);
 	EXPECT_EQ(StringIdentifier("<null>"), *o);
 
 	EXPECT_EQ(0, m.close());
@@ -112,7 +112,7 @@ TEST(MeterFile, format1) {
 
 TEST(MeterFile, format2) {
 	char tempfilename[L_tmpnam + 1];
-	ASSERT_NE(tmpnam(tempfilename), (char *)0);
+	ASSERT_NE(tmpnam(tempfilename), nullptr);
 	std::list<Option> options;
 	options.push_back(Option("path", tempfilename));
 	options.push_back(Option("format", (char *)"$i : $v"));
@@ -140,14 +140,14 @@ TEST(MeterFile, format2) {
 	double value = rds[0].value();
 	EXPECT_EQ(32552, value);
 	StringIdentifier *o = dynamic_cast<StringIdentifier *>(p);
-	ASSERT_NE((StringIdentifier *)0, o);
+	ASSERT_NE(nullptr, o);
 	EXPECT_EQ(StringIdentifier("id1"), *o);
 
 	value = rds[1].value();
 	p = rds[1].identifier().get();
 	o = dynamic_cast<StringIdentifier *>(p);
 	EXPECT_EQ(32552.5, value);
-	ASSERT_NE((StringIdentifier *)0, o);
+	ASSERT_NE(nullptr, o);
 	EXPECT_EQ(StringIdentifier("id2"), *o);
 
 	EXPECT_EQ(0, m.close());
@@ -173,7 +173,7 @@ TEST(MeterFile, reading_times) {
 
 TEST(MeterFile, format3) {
 	char tempfilename[L_tmpnam + 1];
-	ASSERT_NE(tmpnam(tempfilename), (char *)0);
+	ASSERT_NE(tmpnam(tempfilename), nullptr);
 	std::list<Option> options;
 	options.push_back(Option("path", tempfilename));
 	options.push_back(Option("format", (char *)"$t;$i : $v"));
@@ -203,7 +203,7 @@ TEST(MeterFile, format3) {
 	EXPECT_EQ(1001200ll, rds[0].time_ms()) << rds[0].time_ms();
 
 	StringIdentifier *o = dynamic_cast<StringIdentifier *>(p);
-	ASSERT_NE((StringIdentifier *)0, o);
+	ASSERT_NE(nullptr, o);
 	EXPECT_EQ(StringIdentifier("id1"), *o);
 
 	value = rds[1].value();
@@ -211,7 +211,7 @@ TEST(MeterFile, format3) {
 	o = dynamic_cast<StringIdentifier *>(p);
 	EXPECT_EQ(32552.5, value);
 	EXPECT_EQ(1002500ll, rds[1].time_ms());
-	ASSERT_NE((StringIdentifier *)0, o);
+	ASSERT_NE(nullptr, o);
 	EXPECT_EQ(StringIdentifier("id2"), *o);
 
 	EXPECT_EQ(0, m.close());

--- a/tests/ut_PushData.cpp
+++ b/tests/ut_PushData.cpp
@@ -5,9 +5,9 @@
 #include "../src/PushData.cpp"
 
 TEST(PushData, PDL_basic_constructor) {
-	ASSERT_EQ(0, pushDataList);
+	ASSERT_EQ(nullptr, pushDataList);
 	PushDataList pdl;
-	ASSERT_EQ(0, pushDataList);
+	ASSERT_EQ(nullptr, pushDataList);
 }
 
 TEST(PushData, PDL_basic_add) {
@@ -20,7 +20,7 @@ TEST(PushData, PDL_basic_waitForData) {
 	PushDataList pdl;
 	pdl.add("0", 1, 1.0);
 	PushDataList::DataMap *dm = pdl.waitForData();
-	ASSERT_TRUE(0 != dm);
+	ASSERT_TRUE(nullptr != dm);
 	ASSERT_EQ(1ul, dm->size());
 	delete dm;
 }
@@ -30,7 +30,7 @@ TEST(PushData, PDL_basic_waitForData2) {
 	pdl.add("0", 1, 1.0);
 	pdl.add("0", 2, 2.0);
 	PushDataList::DataMap *dm = pdl.waitForData();
-	ASSERT_TRUE(0 != dm);
+	ASSERT_TRUE(nullptr != dm);
 	ASSERT_EQ(1ul, dm->size()); // still one uuid
 	ASSERT_EQ(2ul, dm->operator[]("0").size());
 	delete dm;
@@ -42,7 +42,7 @@ TEST(PushData, PDL_basic_waitForData3) {
 	pdl.add("0", 2, 2.0);
 	pdl.add("1", 3, 3.0);
 	PushDataList::DataMap *dm = pdl.waitForData();
-	ASSERT_TRUE(0 != dm);
+	ASSERT_TRUE(nullptr != dm);
 	ASSERT_EQ(2ul, dm->size()); // now two uuids
 	ASSERT_EQ(2ul, dm->operator[]("0").size());
 	ASSERT_EQ(1ul, dm->operator[]("1").size());
@@ -53,12 +53,12 @@ TEST(PushData, PDL_basic_waitForData4) {
 	PushDataList pdl;
 	pdl.add("0", 1, 1.0);
 	PushDataList::DataMap *dm = pdl.waitForData();
-	ASSERT_TRUE(0 != dm);
+	ASSERT_TRUE(nullptr != dm);
 	ASSERT_EQ(1ul, dm->size());
 	delete dm;
 	pdl.add("1", 4, 4.4);
 	dm = pdl.waitForData();
-	ASSERT_TRUE(0 != dm);
+	ASSERT_TRUE(nullptr != dm);
 	ASSERT_EQ(1ul, dm->size());
 	ASSERT_EQ(4.4, dm->operator[]("1").back().second);
 	delete dm;
@@ -74,23 +74,23 @@ class PushDataServerTest {
 	PushDataServer &_pds;
 };
 
-TEST(PushData, PDS_only_constructor) { PushDataServer pds(0); }
+TEST(PushData, PDS_only_constructor) { PushDataServer pds(nullptr); }
 
 TEST(PushData, PDS_constructor) {
-	PushDataServer pds(0);
+	PushDataServer pds(nullptr);
 	PushDataServerTest pt(pds);
 
 	PushDataList pdl;
 	pdl.add("0", 1, 1.1);
 	PushDataList::DataMap *dm = pdl.waitForData();
-	ASSERT_TRUE(0 != dm);
+	ASSERT_TRUE(nullptr != dm);
 	std::string str = pt.generateJson(*dm);
 	// todo fix the comparision! 1.10000 vs. 1.10000001, ... ASSERT_EQ("{ \"data\": [ { \"uuid\":
 	// \"0\", \"tuples\": [ [ 1, 1.100000 ] ] } ] }", str);
 }
 
 TEST(PushData, PDS_fail_middleware) {
-	ASSERT_EQ(0, curlSessionProvider);
+	ASSERT_EQ(nullptr, curlSessionProvider);
 	curlSessionProvider = new CurlSessionProvider();
 
 	struct json_object *jso =
@@ -104,8 +104,8 @@ TEST(PushData, PDS_fail_middleware) {
 	pushDataList = &pdl;
 	ASSERT_FALSE(pds.waitAndSendOnceToAll()); // we assume that localhost:45431/unit_test/push.json
 											  // can't be connected to
-	pushDataList = 0;
+	pushDataList = nullptr;
 
 	delete curlSessionProvider;
-	curlSessionProvider = 0;
+	curlSessionProvider = nullptr;
 }

--- a/tests/ut_api_volkszaehler.cpp
+++ b/tests/ut_api_volkszaehler.cpp
@@ -71,7 +71,7 @@ TEST(api_Volkszaehler, no_middleware) {
 TEST(api_Volkszaehler, api_parse_exception) {
 	using namespace vz::api;
 	CURLresponse resp;
-	resp.data = 0;
+	resp.data = nullptr;
 	resp.size = 0;
 	char *err = new char[100];
 	err[0] = 0;
@@ -96,7 +96,7 @@ TEST(api_Volkszaehler, api_parse_exception) {
 
 	// test using corrupted resp data:
 	resp.size = 100;
-	resp.data = 0;
+	resp.data = nullptr;
 	// todo: this crashes! Volkszaehler_Test::api_parse_exception(v, resp, err, n);
 
 	// test using empty json resp:
@@ -155,7 +155,7 @@ TEST(api_Volkszaehler, api_json_tuples_no_duplicates) {
 
 	// test using empty data:
 	json_object *j = Volkszaehler_Test::api_json_tuples(v, ch->buffer());
-	ASSERT_TRUE(j == 0);
+	ASSERT_TRUE(j == nullptr);
 	ASSERT_TRUE(Volkszaehler_Test::values(v).size() == 0);
 
 	struct timeval t1;
@@ -170,7 +170,7 @@ TEST(api_Volkszaehler, api_json_tuples_no_duplicates) {
 
 	// expect one data returned in values:
 	j = Volkszaehler_Test::api_json_tuples(v, ch->buffer());
-	ASSERT_TRUE(j != 0);
+	ASSERT_TRUE(j != nullptr);
 	ASSERT_TRUE(Volkszaehler_Test::values(v).size() == 1);
 	ASSERT_EQ(Volkszaehler_Test::values(v).front(), r1);
 	json_object_put(j);
@@ -181,7 +181,7 @@ TEST(api_Volkszaehler, api_json_tuples_no_duplicates) {
 	ch->push(r2);
 	// expect only two data returned in values: (r1 ignored as timestamp same as previous) and r2)
 	j = Volkszaehler_Test::api_json_tuples(v, ch->buffer());
-	ASSERT_TRUE(j != 0);
+	ASSERT_TRUE(j != nullptr);
 	ASSERT_TRUE(Volkszaehler_Test::values(v).size() == 2);
 	ASSERT_EQ(Volkszaehler_Test::values(v).front(), r1);
 	ASSERT_EQ(Volkszaehler_Test::values(v).back(), r2);
@@ -203,7 +203,7 @@ TEST(api_Volkszaehler, api_json_tuples_duplicates) {
 
 	// test using empty data:
 	json_object *j = Volkszaehler_Test::api_json_tuples(v, ch->buffer());
-	ASSERT_TRUE(j == 0);
+	ASSERT_TRUE(j == nullptr);
 	ASSERT_TRUE(Volkszaehler_Test::values(v).size() == 0);
 
 	struct timeval t1;
@@ -218,7 +218,7 @@ TEST(api_Volkszaehler, api_json_tuples_duplicates) {
 
 	// expect one data returned in values:
 	j = Volkszaehler_Test::api_json_tuples(v, ch->buffer());
-	ASSERT_TRUE(j != 0);
+	ASSERT_TRUE(j != nullptr);
 	ASSERT_TRUE(Volkszaehler_Test::values(v).size() == 1);
 	ASSERT_EQ(Volkszaehler_Test::values(v).front(), r1);
 	json_object_put(j);
@@ -229,7 +229,7 @@ TEST(api_Volkszaehler, api_json_tuples_duplicates) {
 	ch->push(r2);
 	// expect one data returned in values: (r1 same timestamp, r2 ignored)
 	j = Volkszaehler_Test::api_json_tuples(v, ch->buffer());
-	ASSERT_TRUE(j != 0);
+	ASSERT_TRUE(j != nullptr);
 	ASSERT_TRUE(Volkszaehler_Test::values(v).size() == 1);
 	ASSERT_EQ(Volkszaehler_Test::values(v).front(), r1);
 
@@ -246,7 +246,7 @@ TEST(api_Volkszaehler, api_json_tuples_duplicates) {
 	// now add one with a different value:
 	// then we should get r1 and the new value r3:
 	j = Volkszaehler_Test::api_json_tuples(v, ch->buffer());
-	ASSERT_TRUE(j != 0);
+	ASSERT_TRUE(j != nullptr);
 	ASSERT_TRUE(Volkszaehler_Test::values(v).size() == 2);
 	ASSERT_EQ(Volkszaehler_Test::values(v).front(), r1);
 	Volkszaehler_Test::values(v).pop_front();
@@ -263,7 +263,7 @@ TEST(api_Volkszaehler, api_json_tuples_duplicates) {
 	ch->push(r4);
 	// now there should be r3 and r4:
 	j = Volkszaehler_Test::api_json_tuples(v, ch->buffer());
-	ASSERT_TRUE(j != 0);
+	ASSERT_TRUE(j != nullptr);
 	ASSERT_TRUE(Volkszaehler_Test::values(v).size() == 2) << Volkszaehler_Test::values(v).size();
 	ASSERT_EQ(Volkszaehler_Test::values(v).front(), r3);
 	Volkszaehler_Test::values(v).pop_front();
@@ -279,7 +279,7 @@ TEST(api_Volkszaehler, api_json_tuples_duplicates) {
 	Reading r5(5.0, t1, pRid);
 	ch->push(r5);
 	j = Volkszaehler_Test::api_json_tuples(v, ch->buffer());
-	ASSERT_TRUE(j != 0);
+	ASSERT_TRUE(j != nullptr);
 	ASSERT_TRUE(Volkszaehler_Test::values(v).size() == 1) << Volkszaehler_Test::values(v).size();
 	ASSERT_EQ(Volkszaehler_Test::values(v).front(), r5);
 	Volkszaehler_Test::values(v).pop_front();
@@ -292,7 +292,7 @@ TEST(api_Volkszaehler, api_json_tuples_duplicates) {
 	Reading r6(5.0, t1, pRid);
 	ch->push(r6);
 	j = Volkszaehler_Test::api_json_tuples(v, ch->buffer());
-	ASSERT_TRUE(j == 0);
+	ASSERT_TRUE(j == nullptr);
 	ASSERT_TRUE(Volkszaehler_Test::values(v).size() == 0) << Volkszaehler_Test::values(v).size();
 
 	ASSERT_TRUE(ch->buffer()->size() == 0);
@@ -304,7 +304,7 @@ TEST(api_Volkszaehler, api_json_tuples_duplicates) {
 	Reading r7(7.0, t1, pRid);
 	ch->push(r7);
 	j = Volkszaehler_Test::api_json_tuples(v, ch->buffer());
-	ASSERT_TRUE(j != 0);
+	ASSERT_TRUE(j != nullptr);
 	ASSERT_TRUE(Volkszaehler_Test::values(v).size() == 1) << Volkszaehler_Test::values(v).size();
 	ASSERT_EQ(Volkszaehler_Test::values(v).front(), r7);
 	Volkszaehler_Test::values(v).pop_front();

--- a/tests/ut_meter.cpp
+++ b/tests/ut_meter.cpp
@@ -22,29 +22,29 @@
 #include "../src/protocols/MeterS0.cpp"
 
 TEST(meter, meter_lookup_protocol) {
-	ASSERT_EQ(ERR_NOT_FOUND, meter_lookup_protocol(NULL, NULL));
-	ASSERT_EQ(SUCCESS, meter_lookup_protocol("d0", NULL));
-	ASSERT_EQ(SUCCESS, meter_lookup_protocol("D0", NULL)); // case insensitive
+	ASSERT_EQ(ERR_NOT_FOUND, meter_lookup_protocol(nullptr, nullptr));
+	ASSERT_EQ(SUCCESS, meter_lookup_protocol("d0", nullptr));
+	ASSERT_EQ(SUCCESS, meter_lookup_protocol("D0", nullptr)); // case insensitive
 
-	ASSERT_EQ(ERR_NOT_FOUND, meter_lookup_protocol("D1", NULL));
+	ASSERT_EQ(ERR_NOT_FOUND, meter_lookup_protocol("D1", nullptr));
 
-	ASSERT_EQ(SUCCESS, meter_lookup_protocol("file", NULL));
-	ASSERT_EQ(SUCCESS, meter_lookup_protocol("exec", NULL));
+	ASSERT_EQ(SUCCESS, meter_lookup_protocol("file", nullptr));
+	ASSERT_EQ(SUCCESS, meter_lookup_protocol("exec", nullptr));
 
-	ASSERT_EQ(SUCCESS, meter_lookup_protocol("random", NULL));
-	ASSERT_EQ(SUCCESS, meter_lookup_protocol("s0", NULL));
+	ASSERT_EQ(SUCCESS, meter_lookup_protocol("random", nullptr));
+	ASSERT_EQ(SUCCESS, meter_lookup_protocol("s0", nullptr));
 #ifdef SML_SUPPORT
-	ASSERT_EQ(SUCCESS, meter_lookup_protocol("sml", NULL));
+	ASSERT_EQ(SUCCESS, meter_lookup_protocol("sml", nullptr));
 #endif
-	ASSERT_EQ(SUCCESS, meter_lookup_protocol("fluksov2", NULL));
+	ASSERT_EQ(SUCCESS, meter_lookup_protocol("fluksov2", nullptr));
 
-	ASSERT_EQ(ERR_NOT_FOUND, meter_lookup_protocol("d01", NULL));
-	ASSERT_EQ(ERR_NOT_FOUND, meter_lookup_protocol("", NULL));
+	ASSERT_EQ(ERR_NOT_FOUND, meter_lookup_protocol("d01", nullptr));
+	ASSERT_EQ(ERR_NOT_FOUND, meter_lookup_protocol("", nullptr));
 	meter_protocol_t m = meter_protocol_none;
 	ASSERT_EQ(SUCCESS, meter_lookup_protocol("d0", &m));
 	ASSERT_EQ(meter_protocol_d0, m);
 	const meter_details_t *d = meter_get_details(m);
-	ASSERT_TRUE(NULL != d);
-	ASSERT_TRUE(NULL != d->name);
+	ASSERT_TRUE(nullptr != d);
+	ASSERT_TRUE(nullptr != d->name);
 	ASSERT_STREQ(d->name, "d0");
 }


### PR DESCRIPTION
Since C++11 NULL or 0 should no longer be used to check for null pointers or to set a pointer to null.