### PR TITLE
Changes from the first Debian Review

### DIFF
--- a/debian/DEBIAN_RELEASE.txt
+++ b/debian/DEBIAN_RELEASE.txt
@@ -10,7 +10,9 @@ Steps for creating an official Debian release
 4. Retrieve the current changelog with 
    curl -o debian/changelog https://metadata.ftp-master.debian.org/changelogs//main/libs/vzlogger/vzlogger_<previous debian version>_changelog
 5. Prepend a new changelog entry.
-6. Commit.
-7. Create orig tarball
+6. Remove the debian relase files
+   git rm debian/Debian_release.patch debian/DEBIAN_RELEASE.txt
+7. Commit.
+8. Create orig tarball
    git archive --output=../vzlogger_$(dpkg-parsechangelog --show-field Version 2>/dev/null | cut -f1 -d-).orig.tar.gz --format=tar.gz HEAD
 

--- a/debian/Debian_release.patch
+++ b/debian/Debian_release.patch
@@ -1,27 +1,17 @@
-From 496c843f57a7561737eb8c49ae14bae8fc4c5367 Mon Sep 17 00:00:00 2001
+From faa2a55d0565c4cb6c987ff524779a984d52b258 Mon Sep 17 00:00:00 2001
 From: Joachim Zobel <jz-2017@heute-morgen.de>
-Date: Sat, 24 Feb 2024 06:49:49 +0100
-Subject: Patch to make a release suitable for Debian 
+Date: Sat, 24 Feb 2024 15:16:30 +0100
+Subject: Patch to make a release suitable for Debian
 
 ---
- .gitattributes                  |  1 +
  debian/compat                   |  1 -
- debian/control                  |  8 ++++----
  debian/source/format            |  2 +-
- debian/source/lintian-overrides |  2 --
+ debian/source/lintian-overrides |  4 ----
  etc/vzlogger.conf               | 23 +++++++++++++++++++++++
- 6 files changed, 29 insertions(+), 8 deletions(-)
- create mode 100644 .gitattributes
+ 4 files changed, 24 insertions(+), 6 deletions(-)
  delete mode 100644 debian/compat
  delete mode 100644 debian/source/lintian-overrides
 
-diff --git a/.gitattributes b/.gitattributes
-new file mode 100644
-index 0000000..9bedf0b
---- /dev/null
-+++ b/.gitattributes
-@@ -0,0 +1 @@
-+debian/ export-ignore
 diff --git a/debian/compat b/debian/compat
 deleted file mode 100644
 index 48082f7..0000000
@@ -29,29 +19,6 @@ index 48082f7..0000000
 +++ /dev/null
 @@ -1 +0,0 @@
 -12
-diff --git a/debian/control b/debian/control
-index 0b190ae..9e8a7fe 100644
---- a/debian/control
-+++ b/debian/control
-@@ -2,14 +2,14 @@ Source: vzlogger
- Section: net
- Priority: optional
- Maintainer: Joachim Zobel <jz-2017@heute-morgen.de>
--Build-Depends: debhelper (>= 12), pkg-config (>= 0.25), 
-+Build-Depends: debhelper-compat (= 13), pkg-config (>= 0.25), 
-  libjson-c-dev (>= 0.9), libcurl4-openssl-dev (>= 7.19),
-  libmicrohttpd-dev (>= 0.4.6), libsml-dev (>= 1.0), cmake, libsasl2-dev,
-- libssl-dev, libgcrypt-dev, libgnutls28-dev, uuid-dev, libunistring-dev,
-+ libssl-dev (>= 3.0), libgcrypt-dev, libgnutls28-dev, uuid-dev, libunistring-dev,
-  libgmock-dev, libgtest-dev, pandoc, libmosquitto-dev
--Standards-Version: 4.6.1
-+Standards-Version: 4.6.2
- Homepage: http://wiki.volkszaehler.org/software/controller/vzlogger
--Vcs-Git: https://github.com/volkszaehler/vzlogger.git
-+Vcs-Git: https://github.com/volkszaehler/vzlogger.git -b debian-
- Vcs-Browser: https://github.com/volkszaehler/vzlogger
- 
- Package: vzlogger
 diff --git a/debian/source/format b/debian/source/format
 index 89ae9db..163aaf8 100644
 --- a/debian/source/format
@@ -61,12 +28,14 @@ index 89ae9db..163aaf8 100644
 +3.0 (quilt)
 diff --git a/debian/source/lintian-overrides b/debian/source/lintian-overrides
 deleted file mode 100644
-index 09c5b1d..0000000
+index 8261c3d..0000000
 --- a/debian/source/lintian-overrides
 +++ /dev/null
-@@ -1,2 +0,0 @@
+@@ -1,4 +0,0 @@
 -# May be odd, but I don't want to change the (non debian) past
 -odd-historical-debian-changelog-version *0.3.4-rc1*
+-# Having a debian watch file in the native package is easier to maintain
+-debian-watch-file-in-native-package *
 diff --git a/etc/vzlogger.conf b/etc/vzlogger.conf
 index f30363e..48aa76b 100644
 --- a/etc/vzlogger.conf

--- a/debian/Debian_release.patch
+++ b/debian/Debian_release.patch
@@ -1,3 +1,20 @@
+From 496c843f57a7561737eb8c49ae14bae8fc4c5367 Mon Sep 17 00:00:00 2001
+From: Joachim Zobel <jz-2017@heute-morgen.de>
+Date: Sat, 24 Feb 2024 06:49:49 +0100
+Subject: Patch to make a release suitable for Debian 
+
+---
+ .gitattributes                  |  1 +
+ debian/compat                   |  1 -
+ debian/control                  |  8 ++++----
+ debian/source/format            |  2 +-
+ debian/source/lintian-overrides |  2 --
+ etc/vzlogger.conf               | 23 +++++++++++++++++++++++
+ 6 files changed, 29 insertions(+), 8 deletions(-)
+ create mode 100644 .gitattributes
+ delete mode 100644 debian/compat
+ delete mode 100644 debian/source/lintian-overrides
+
 diff --git a/.gitattributes b/.gitattributes
 new file mode 100644
 index 0000000..9bedf0b
@@ -42,6 +59,14 @@ index 89ae9db..163aaf8 100644
 @@ -1 +1 @@
 -3.0 (native)
 +3.0 (quilt)
+diff --git a/debian/source/lintian-overrides b/debian/source/lintian-overrides
+deleted file mode 100644
+index 09c5b1d..0000000
+--- a/debian/source/lintian-overrides
++++ /dev/null
+@@ -1,2 +0,0 @@
+-# May be odd, but I don't want to change the (non debian) past
+-odd-historical-debian-changelog-version *0.3.4-rc1*
 diff --git a/etc/vzlogger.conf b/etc/vzlogger.conf
 index f30363e..48aa76b 100644
 --- a/etc/vzlogger.conf
@@ -86,3 +111,6 @@ index f30363e..48aa76b 100644
          {
              "enabled": false,               // disabled meters will be ignored
              "allowskip": false,                  // errors when opening meter may be ignored if enabled
+-- 
+2.39.2
+

--- a/debian/control
+++ b/debian/control
@@ -2,19 +2,20 @@ Source: vzlogger
 Section: net
 Priority: optional
 Maintainer: Joachim Zobel <jz-2017@heute-morgen.de>
-Build-Depends: debhelper (>= 12), pkg-config (>= 0.25), 
- libjson-c-dev (>= 0.9), libcurl4-openssl-dev (>= 7.19),
+Build-Depends: debhelper (>= 12), pkgconf, 
+ libjson-c-dev, libcurl4-openssl-dev,
  libmicrohttpd-dev (>= 0.4.6), libsml-dev (>= 1.0), cmake, libsasl2-dev,
  libssl-dev, libgcrypt-dev, libgnutls28-dev, uuid-dev, libunistring-dev,
  libgmock-dev, libgtest-dev, pandoc, libmosquitto-dev
-Standards-Version: 4.6.1
+Standards-Version: 4.6.2
+Rules-Requires-Root: no
 Homepage: http://wiki.volkszaehler.org/software/controller/vzlogger
 Vcs-Git: https://github.com/volkszaehler/vzlogger.git
 Vcs-Browser: https://github.com/volkszaehler/vzlogger
 
 Package: vzlogger
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, adduser, libsml1
+Depends: ${shlibs:Depends}, ${misc:Depends}, adduser
 Pre-Depends: ${misc:Pre-Depends}
 Description: program for logging measurements to a volkszaehler.org middleware
  vzlogger...

--- a/debian/rules
+++ b/debian/rules
@@ -24,6 +24,10 @@ override_dh_auto_configure:
 	dh_auto_configure -- -DBUILD_TEST=off
 endif
 
+override_dh_installsystemd:
+	# stop the service during install, see man dh_installsystemd
+	dh_installsystemd --no-restart-after-upgrade
+
 ifneq (,$(filter nocheck,$(DEB_BUILD_OPTIONS)))
 override_dh_auto_test: ;
 endif

--- a/debian/source/lintian-overrides
+++ b/debian/source/lintian-overrides
@@ -1,2 +1,4 @@
 # May be odd, but I don't want to change the (non debian) past
 odd-historical-debian-changelog-version *0.3.4-rc1*
+# Having a debian watch file in the native package is easier to maintain
+debian-watch-file-in-native-package *

--- a/debian/vzlogger.init
+++ b/debian/vzlogger.init
@@ -18,8 +18,8 @@ DAEMON=/usr/bin/vzlogger
 DAEMON_ARGS="-d"          # Arguments to run the daemon with
 #PIDFILE=/var/run/$NAME.pid
 SCRIPTNAME=/etc/init.d/$NAME
-USER=vzlogger
-GROUP=vzlogger
+USER=_vzlogger
+GROUP=_vzlogger
 
 # Exit if the package is not installed
 [ -x $DAEMON ] || exit 0

--- a/debian/vzlogger.postinst
+++ b/debian/vzlogger.postinst
@@ -4,15 +4,20 @@ set -e
 
 case "$1" in
     configure)
-    if ! id vzlogger > /dev/null 2>&1 ; then
+    if id vzlogger > /dev/null 2>&1 ; then
+		# maintain compatibility with existing native installations
+		usermod -l _vzlogger vzlogger	
+		groupmod --new-name _vzlogger vzlogger
+	fi
+    if ! id _vzlogger > /dev/null 2>&1 ; then
         adduser --quiet --system --no-create-home --home /nonexistent \
             --group --disabled-password --shell /bin/false \
-            vzlogger
-        usermod -a -G dialout vzlogger
+            _vzlogger
+        usermod -a -G dialout _vzlogger
     fi
 
     touch /var/log/vzlogger.log
-    chown vzlogger:adm /var/log/vzlogger.log
+    chown _vzlogger:adm /var/log/vzlogger.log
     ;;
 
     abort-upgrade|abort-remove|abort-deconfigure)

--- a/debian/vzlogger.postrm
+++ b/debian/vzlogger.postrm
@@ -5,8 +5,6 @@ set -e
 case "$1" in
     purge)
     rm -f /var/log/vzlogger.log*
-    deluser --quiet --system vzlogger
-    delgroup --quiet --system vzlogger
     ;;
 
     remove|abort-install|abort-upgrade|disappear)

--- a/debian/vzlogger.service
+++ b/debian/vzlogger.service
@@ -4,8 +4,8 @@ After=network.target ntp.service
 
 [Service]
 ExecStart=/usr/bin/vzlogger -c /etc/vzlogger.conf
-User=vzlogger
-Group=vzlogger
+User=_vzlogger
+Group=_vzlogger
 ExecReload=
 StandardOutput=null
 


### PR DESCRIPTION
Note that this changes the name of the service user to _vzlogger to comply with Debian policy 9.2.1.