### PR TITLE
[cmake] print warning if oms not enabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -289,6 +289,10 @@ if( ENABLE_LOCAL AND NOT MICROHTTPD_FOUND )
 Install microhttpd or call cmake -DMICROHTTPD_HOME=path_to_microhttpd_install")
 endif( ENABLE_LOCAL AND NOT MICROHTTPD_FOUND )
 
+if( ENABLE_OMS AND NOT OMS_SUPPORT)
+  message(WARNING "oms support not being enabled (libmbus not found)")
+endif( ENABLE_OMS AND NOT OMS_SUPPORT)
+
 # add clean-all target that removes the cached files from cmake as well (see e.g. issue #186)
 add_custom_target(clean-all
     COMMAND ${CMAKE_BUILD_TOOL} clean


### PR DESCRIPTION
this is the possible learning from https://github.com/volkszaehler/vzlogger/issues/642 :
print a warning if oms is not being enabled, just like for sml.

questions:
- this means the warning will be printed for most users, is this OK or possibly confusing?
  - this is the same as for sml, but sml is required by most of our users
  - should oms maybe not be enabled by default? (but that would just lead to repeats of !624 )
- code-wise there's three variables involved (like for sml):
  - `ENABLE_*`: user inpput to request feature (set by default)
  - `*_FOUND`: result of library search
  -  `*_SUPPORT`: set conditional if feature can be enabled
  the sml warning uses `ENABLE AND NOT FOUND`,
  i rather use `ENABLE AND NOT SUPPORTED` to avoid duplicating the decision process. 
  but it's inconsistent... but probably irrelevant.