### PR TITLE
Improved Debian/Raspbian section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,25 +43,39 @@ You can start it:
 where /home/pi/projects/vzlogger-docker is the path to the directory containing the vzlogger.conf file and
 /dev/serial/by-id/usb-FTDI_FT230X_Basic_UART_D30A8U6N-if00-port0 is your device. You can pass several devices if you have them.
 
-Debian and Raspbian Packages
+Debian and Raspberry Pi OS Packages
 -------------
 
 [![Hosted By: Cloudsmith](https://img.shields.io/badge/OSS%20hosting%20by-cloudsmith-blue?logo=cloudsmith&style=flat-square)](https://cloudsmith.com)
 
-We now build Debian packages for amd64, armhf and arm64 and Raspbian packages 
-for armhf as part of our releases. Unfortunately Debian armhf packages do not 
-run on Raspberry Pi 1 although the architecture on the RPi is named armhf. 
-Using Raspian armhf packages fixes that.
+We now build Debian packages for amd64, armhf and arm64. Armel, which would be
+needed for Debian on RPi 1 hardware, is not supported.
 
-The ones attached to the release are meant for debian trixie. These and 
-packages for bookworm and bullseye are also provided through a repository 
-graciously provided by [Cloudsmith](https://cloudsmith.com).
+[Raspberry Pi OS packages for armhf](
+https://cloudsmith.io/~volkszaehler/repos/volkszaehler-org-project/packages/?q=distribution%3Araspbian+AND+architecture%3Aarmhf) 
+are also part of our releases. Unfortunately 
+Debian armhf packages do not run on Raspberry Pi 1 although the architecture 
+has been named armhf in Raspbian. Using "Raspbian armhf" packages fixes that.
+For RPi 2 and above Debian packages run on Raspberry Pi OS. 
 
-Those debian packages are built with MQTT support.
+Our packages are built with MQTT support, but without OMS support.
+
+The packages attached to the release are meant for Debian trixie. The full set
+of packages is provided through a repository graciously provided by 
+[Cloudsmith](https://cloudsmith.com).
 
 The setup of the repository is also 
 [explained by Cloudsmith](https://cloudsmith.io/~volkszaehler/repos/volkszaehler-org-project/setup/#formats-deb).
-This boils down to adding a file to /etc/apt/sources.list.d/ containing
+The easy way to do it is running 
+```
+curl -1sLf \
+  'https://dl.cloudsmith.io/public/volkszaehler/volkszaehler-org-project/setup.deb.sh' \
+  | sudo -E bash
+```
+If you do it the easy way you should however be aware of the high amount of 
+trust you put into cloudsmith not beeing compromised. As an alternative there 
+is the manual way to achive the same result. That starts with adding a file to
+/etc/apt/sources.list.d/ containing
 ```
 deb [signed-by=/usr/share/keyrings/volkszaehler-volkszaehler-org-project-archive-keyring.gpg] https://dl.cloudsmith.io/public/volkszaehler/volkszaehler-org-project/deb/debian bookworm main
 deb-src [signed-by=/usr/share/keyrings/volkszaehler-volkszaehler-org-project-archive-keyring.gpg] https://dl.cloudsmith.io/public/volkszaehler/volkszaehler-org-project/deb/debian bookworm main
@@ -73,6 +87,15 @@ trusted one.
 curl -1sLf "https://dl.cloudsmith.io/public/volkszaehler/volkszaehler-org-project/gpg.21DBDAC56DF44DA1.key" | \
 	gpg --dearmor > /usr/share/keyrings/volkszaehler-volkszaehler-org-project-archive-keyring.gpg
 ```
+
+After that you can do the usual
+```
+apt update
+apt install vzlogger
+```
+
+An official Debian vzlogger package is currently in unstable.
+ 
 
 Mailing List
 -------------


### PR DESCRIPTION
I tried to improve the Debian/Raspian section and added "no OMS" and "vzlogger in Debian unstable".

Not sure if I really improved things, any suggestions are welcome.