### PR TITLE
Updated minimum required CMake version of gtest to 3.5

### DIFF
--- a/gtest/CMakeLists.txt.in
+++ b/gtest/CMakeLists.txt.in
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.2)
+cmake_minimum_required(VERSION 3.5)
 
 project(gtest-download NONE)
 


### PR DESCRIPTION
When configuring with cmake version 4.1.3, the minimum accepted cmake version is 3.5. Updating the minimum required version to build gtest resolves this issue. The change is consistent with the minimum cmake version required by vzlogger, which is also 3.5.