### PR TITLE
Fixed version set for alpine to achieve error-free build.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # STEP 1 build executable binary
 ############################
 
-FROM alpine:latest AS builder
+FROM alpine:3.20 AS builder
 
 RUN apk add --no-cache \
     gcc \


### PR DESCRIPTION
Yesterday (February 19, 2026), I tried to build vzlogger using Docker. When creating the builder image, compiler errors occurred, presumably because the code no longer works with the current build tools in Alpine:latest. vzlogger compiles without errors with Alpine:3.20.