### PR TITLE
allow a mnemonic MQTT topic instead of hardcoded chn<number>

### DIFF
--- a/include/Channel.hpp
+++ b/include/Channel.hpp
@@ -74,6 +74,7 @@ class Channel {
 
 	const char *name() const { return _name.c_str(); }
 	std::list<Option> &options() { return _options; }
+	std::string mqttTopic() const { return _mqttTopic; }
 
 	ReadingIdentifier::Ptr identifier() {
 		if (_identifier.use_count() < 1)
@@ -116,6 +117,7 @@ class Channel {
 	std::string _name; // name of the channel
 	std::list<Option> _options;
 
+	std::string _mqttTopic;
 	Buffer::Ptr _buffer; // circular queue to buffer readings
 
 	ReadingIdentifier::Ptr _identifier; // channel identifier (OBIS, string)

--- a/src/Channel.cpp
+++ b/src/Channel.cpp
@@ -86,6 +86,11 @@ Channel::Channel(const std::list<Option> &pOptions, const std::string apiProtoco
 		throw;
 	}
 
+	try {
+		_mqttTopic = optlist.lookup_string(pOptions, "mqtt_topic");
+	} catch (vz::OptionNotFoundException &e) {
+		// optional, defaults to empty string
+	}
 	pthread_cond_init(&condition, NULL); // initialize thread syncronization helpers
 }
 

--- a/src/mqtt.cpp
+++ b/src/mqtt.cpp
@@ -222,7 +222,8 @@ MqttClient::~MqttClient() {
 void MqttClient::ChannelEntry::generateNames(const std::string &prefix, Channel &ch) {
 	_announceValues.clear();
 	_fullTopicRaw = prefix;
-	_fullTopicRaw += ch.name(); // todo this converts from std::string to const char and back...
+	// Use configured mqtt_topic if set, otherwise fall back to ch.name()
+	_fullTopicRaw += (!ch.mqttTopic().empty()) ? ch.mqttTopic() : ch.name();
 	_fullTopicRaw += '/';
 	if (ch.identifier()) {
 		char unparseBuf[200];


### PR DESCRIPTION
This backwards-compatible change allows one to set the mqtt topic from the channel configuration. Currently, the meter values are published via an mqtt topic that is set to the channel number, which changes whenever a new channel is defined or and old deleted. And it's totally not mnemonic.

Configuration example:
```
   "meters": [
        { 
            // bidirectional Power Meter external
            "enabled": true,
            "skip": false,
            "protocol": "sml",
            "device": "/dev/USBserialNetz",
            "baudrate": 9600, 
            "parity": "8n1", 
            "read_timeout": 60, 
            "aggtime": 60,
            "aggmode": "max",
            "aggfixedinterval": true,
            "use_local_time": true,
            "channels" : [
                { 
                    "api": "null", 
                    "uuid": "snip", 
                    "mqtt_topic": "1-0:1.8.0_Bezug",
                    "identifier": "1-0:1.8.0" 
                },
                { 
                    "api": "null", 
                    "uuid": "snip", 
                    "mqtt_topic": "1-0:2.8.0_Einspeisung",
                    "identifier": "1-0:2.8.0" 
                }
            ] 
        },
```

This addresses issue #420 from 2020.