### PR TITLE
Fix formatting

### DIFF
--- a/.github/workflows/check-formatting.yml
+++ b/.github/workflows/check-formatting.yml
@@ -5,6 +5,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: install clang-format
-      run: sudo apt-get update && sudo apt-get install clang-format
+      run: sudo apt-get update && sudo apt-get install clang-format-20
     - uses: actions/checkout@v2
     - run: ./check-formatting.sh

--- a/check-formatting.sh
+++ b/check-formatting.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -xe
 SRCDIRS=(include src tests)
-clang-format --version
-find "${SRCDIRS[@]}"  -type f -name '*.h' -o -name '*.cpp' -o -name '*.hpp' | xargs -I{} -P1 clang-format -i -style=file {}
+clang-format-20 --version
+find "${SRCDIRS[@]}"  -type f -name '*.h' -o -name '*.cpp' -o -name '*.hpp' | xargs -I{} -P1 clang-format-20 -i -style=file {}
 [[ -z "$(git status --porcelain "${SRCDIRS[@]}")" ]] || (git status; git diff; false)

--- a/include/ApiIF.hpp
+++ b/include/ApiIF.hpp
@@ -44,7 +44,7 @@ class ApiIF {
 	typedef vz::shared_ptr<ApiIF> Ptr;
 
 	ApiIF(Channel::Ptr ch) : _ch(ch) {}
-	virtual ~ApiIF(){};
+	virtual ~ApiIF() {};
 
 	/**
 	 * @brief send measurement values to middleware

--- a/include/Json.hpp
+++ b/include/Json.hpp
@@ -8,7 +8,7 @@ class Json {
   public:
 	typedef vz::shared_ptr<Json> Ptr;
 
-	Json(struct json_object *jso) : _jso(jso){};
+	Json(struct json_object *jso) : _jso(jso) {};
 	~Json() { _jso = NULL; };
 
 	struct json_object *Object() { return _jso; }

--- a/include/MeterMap.hpp
+++ b/include/MeterMap.hpp
@@ -56,8 +56,8 @@ class MeterMap {
 	MeterMap(const std::list<Option> &options) : _meter(new Meter(options)) {
 		_thread_running = false;
 	}
-	MeterMap(Meter *m) : _meter(m), _thread_running(false){};
-	~MeterMap(){};
+	MeterMap(Meter *m) : _meter(m), _thread_running(false) {};
+	~MeterMap() {};
 	Meter::Ptr meter() { return _meter; }
 
 	/**
@@ -102,8 +102,8 @@ class MapContainer {
 	typedef std::vector<MeterMap>::iterator iterator;
 	typedef std::vector<MeterMap>::const_iterator const_iterator;
 
-	MapContainer(){};
-	~MapContainer(){};
+	MapContainer() {};
+	~MapContainer() {};
 
 	/**
 	 *  Accessor to the MeterMap (meter and its channels) list

--- a/include/Reading.hpp
+++ b/include/Reading.hpp
@@ -43,14 +43,14 @@
 class ReadingIdentifier {
   public:
 	typedef vz::shared_ptr<ReadingIdentifier> Ptr;
-	virtual ~ReadingIdentifier(){};
+	virtual ~ReadingIdentifier() {};
 
 	virtual size_t unparse(char *buffer, size_t n) = 0;
 	bool operator==(ReadingIdentifier const &other) const { return other.isEqual(this); }
 	virtual const std::string toString() = 0;
 
   protected:
-	explicit ReadingIdentifier(){};
+	explicit ReadingIdentifier() {};
 	virtual bool isEqual(ReadingIdentifier const *other) const = 0;
 
   private:
@@ -73,7 +73,7 @@ class ObisIdentifier : public ReadingIdentifier {
 
 	ObisIdentifier() {}
 	ObisIdentifier(Obis obis) : _obis(obis) {}
-	virtual ~ObisIdentifier(){};
+	virtual ~ObisIdentifier() {};
 
 	size_t unparse(char *buffer, size_t n);
 	bool operator==(ObisIdentifier const &other) const { return _obis == other.obis(); }

--- a/include/api/CurlResponse.hpp
+++ b/include/api/CurlResponse.hpp
@@ -37,7 +37,7 @@ class CurlResponse {
 	typedef vz::shared_ptr<CurlResponse> Ptr;
 
 	CurlResponse() : _header(""), _body("") { clear_response(); };
-	~CurlResponse(){};
+	~CurlResponse() {};
 
 	const std::string get_response() { return _response_data; }
 	const std::string body() const { return _body; }

--- a/include/list.h
+++ b/include/list.h
@@ -37,7 +37,7 @@ template <class T> class List {
 	class Iterator; /* public forward declaration */
 	typedef Iterator iterator;
 
-	List() : size(0), head(NULL), tail(NULL){};
+	List() : size(0), head(NULL), tail(NULL) {};
 	~List() { clear(); };
 
 	Iterator push(T data) {
@@ -108,7 +108,7 @@ template <class T> class List<T>::Iterator {
 	friend class List<T>;
 
   public:
-	Iterator() : cur(NULL){};
+	Iterator() : cur(NULL) {};
 
 	bool operator==(Iterator const &i) const { return (cur == i.cur); };
 	bool operator!=(Iterator const &i) const { return (cur != i.cur); };
@@ -122,7 +122,7 @@ template <class T> class List<T>::Iterator {
 	};
 
   protected:
-	Iterator(Node *node) : cur(node){};
+	Iterator(Node *node) : cur(node) {};
 
 	Node *cur;
 };

--- a/include/protocols/MeterOCR.hpp
+++ b/include/protocols/MeterOCR.hpp
@@ -43,7 +43,7 @@ typedef struct Pixa PIXA;
 
 class Reads {
   public:
-	Reads() : value(0.0), min_conf(DBL_MAX){};
+	Reads() : value(0.0), min_conf(DBL_MAX) {};
 	double value;
 	std::string conf_id;
 	double min_conf;
@@ -97,7 +97,7 @@ class MeterOCR : public vz::protocol::Protocol {
 		Recognizer(const std::string &type, struct json_object *);
 		virtual bool recognize(PIX *image, int dX, int dY, ReadsMap &reads,
 							   const ReadsMap *old_reads, PIXA *debugPixa) = 0;
-		virtual ~Recognizer(){};
+		virtual ~Recognizer() {};
 		virtual void getCaptureCoords(int &minX, int &minY, int &maxX, int &maxY) = 0;
 
 	  protected:

--- a/include/protocols/MeterOMS.hpp
+++ b/include/protocols/MeterOMS.hpp
@@ -18,8 +18,8 @@ class MeterOMS : public vz::protocol::Protocol {
 	// abstract hw interface access for testability:
 	class OMSHWif {
 	  public:
-		OMSHWif(){};
-		virtual ~OMSHWif(){};
+		OMSHWif() {};
+		virtual ~OMSHWif() {};
 
 		virtual ssize_t read(void *buf, size_t count) = 0;        // similar to ::read
 		virtual ssize_t write(const void *buf, size_t count) = 0; // similar to ::write

--- a/include/protocols/MeterS0.hpp
+++ b/include/protocols/MeterS0.hpp
@@ -42,7 +42,7 @@ class MeterS0 : public vz::protocol::Protocol {
   public:
 	class HWIF {
 	  public:
-		virtual ~HWIF(){};
+		virtual ~HWIF() {};
 		virtual bool _open() = 0;
 		virtual bool _close() = 0;
 		virtual bool waitForImpulse(bool &timeout) = 0; // blocking interface

--- a/include/protocols/MeterW1therm.hpp
+++ b/include/protocols/MeterW1therm.hpp
@@ -17,8 +17,8 @@ class MeterW1therm : public vz::protocol::Protocol {
 	// abstract hw interface access for testability:
 	class W1HWif {
 	  public:
-		W1HWif(){};
-		virtual ~W1HWif(){};
+		W1HWif() {};
+		virtual ~W1HWif() {};
 
 		virtual bool scanW1devices() = 0; // scan for w1 devices
 		virtual const std::list<std::string> &
@@ -28,8 +28,8 @@ class MeterW1therm : public vz::protocol::Protocol {
 
 	class W1sysHWif : public W1HWif {
 	  public:
-		W1sysHWif(){};
-		virtual ~W1sysHWif(){};
+		W1sysHWif() {};
+		virtual ~W1sysHWif() {};
 
 		virtual bool scanW1devices();
 		virtual const std::list<std::string> &W1devices() const { return _devices; }

--- a/include/protocols/Protocol.hpp
+++ b/include/protocols/Protocol.hpp
@@ -42,9 +42,9 @@ class Protocol {
   public:
 	typedef vz::shared_ptr<Protocol> Ptr;
 
-	Protocol(const std::string &name) : _name(name){};
+	Protocol(const std::string &name) : _name(name) {};
 
-	virtual ~Protocol(){};
+	virtual ~Protocol() {};
 
 	virtual int open() = 0;
 	virtual int close() = 0;

--- a/src/Meter.cpp
+++ b/src/Meter.cpp
@@ -48,8 +48,7 @@
 #endif
 // #include <protocols/.h>
 
-#define METER_DETAIL(NAME, CLASSNAME, DESC, MAX_RDS)                                               \
-	{ meter_protocol_##NAME, #NAME, DESC, MAX_RDS }
+#define METER_DETAIL(NAME, CLASSNAME, DESC, MAX_RDS) {meter_protocol_##NAME, #NAME, DESC, MAX_RDS}
 
 int Meter::instances = 0;
 

--- a/src/local.cpp
+++ b/src/local.cpp
@@ -42,7 +42,7 @@ extern Config_Options options;
 
 class ChannelData {
   public:
-	ChannelData(const int64_t &t, const double &v) : _t(t), _v(v){};
+	ChannelData(const int64_t &t, const double &v) : _t(t), _v(v) {};
 	int64_t _t;
 	double _v;
 };

--- a/tests/mocks/Channel.hpp
+++ b/tests/mocks/Channel.hpp
@@ -10,10 +10,10 @@
 class Channel {
   public:
 	typedef vz::shared_ptr<Channel> Ptr;
-	Channel() : mock_buf(new Buffer()){};
+	Channel() : mock_buf(new Buffer()) {};
 	Channel(const std::list<Option> &pOptions, const std::string api, const std::string pUuid,
 			ReadingIdentifier::Ptr pIdentifier)
-		: mock_buf(new Buffer()){};
+		: mock_buf(new Buffer()) {};
 	MOCK_METHOD1(start, void(Channel::Ptr));
 	MOCK_METHOD0(join, void());
 	MOCK_METHOD0(cancel, void());

--- a/tests/mocks/mock_MeterOMS.cpp
+++ b/tests/mocks/mock_MeterOMS.cpp
@@ -17,7 +17,7 @@ namespace mock_MeterOMS {
 
 class mock_OMShwif : public MeterOMS::OMSHWif {
   public:
-	mock_OMShwif() : returned(0), remain(0), data(0){};
+	mock_OMShwif() : returned(0), remain(0), data(0) {};
 	virtual ~mock_OMShwif() {
 		if (data)
 			free(data);

--- a/tests/mocks/mock_MeterS0.cpp
+++ b/tests/mocks/mock_MeterS0.cpp
@@ -17,8 +17,8 @@ namespace mock_MeterS0 {
 
 class mock_S0hwif : public MeterS0::HWIF {
   public:
-	mock_S0hwif(){};
-	virtual ~mock_S0hwif(){};
+	mock_S0hwif() {};
+	virtual ~mock_S0hwif() {};
 	MOCK_METHOD0(_open, bool());
 	MOCK_METHOD0(_close, bool());
 	MOCK_METHOD1(waitForImpulse, bool(bool &));

--- a/tests/mocks/mock_MeterW1therm.cpp
+++ b/tests/mocks/mock_MeterW1therm.cpp
@@ -16,8 +16,8 @@ namespace mock_MeterW1therm {
 
 class mock_W1hwif : public MeterW1therm::W1HWif {
   public:
-	mock_W1hwif(){};
-	virtual ~mock_W1hwif(){};
+	mock_W1hwif() {};
+	virtual ~mock_W1hwif() {};
 	MOCK_METHOD0(scanW1devices, bool());
 	MOCK_CONST_METHOD0(W1devices, const std::list<std::string> &());
 	MOCK_METHOD2(readTemp, bool(const std::string &dev, double &value));

--- a/tests/mocks/mock_metermap.cpp
+++ b/tests/mocks/mock_metermap.cpp
@@ -20,8 +20,8 @@ namespace mock_metermap {
 
 class mock_meter : public Meter {
   public:
-	mock_meter(const std::list<Option> &o) : Meter(o){};
-	virtual ~mock_meter(){};
+	mock_meter(const std::list<Option> &o) : Meter(o) {};
+	virtual ~mock_meter() {};
 	//    mock_meter() : Meter(std::list<Option>()) {};
 	MOCK_METHOD0(open, void());
 	MOCK_METHOD0(close, int());

--- a/tests/mocks/protocols/MeterOCR.hpp
+++ b/tests/mocks/protocols/MeterOCR.hpp
@@ -10,8 +10,8 @@
 
 class MeterOCR : public vz::protocol::Protocol {
   public:
-	MeterOCR(std::list<Option> options) : Protocol("ocr"){};
-	virtual ~MeterOCR(){};
+	MeterOCR(std::list<Option> options) : Protocol("ocr") {};
+	virtual ~MeterOCR() {};
 	MOCK_METHOD0(open, int());
 	MOCK_METHOD0(close, int());
 	MOCK_METHOD2(read, ssize_t(std::vector<Reading> &rds, size_t n));

--- a/tests/ut_PushData.cpp
+++ b/tests/ut_PushData.cpp
@@ -68,7 +68,7 @@ TEST(PushData, PDL_basic_waitForData4) {
 
 class PushDataServerTest {
   public:
-	PushDataServerTest(PushDataServer &pds) : _pds(pds){};
+	PushDataServerTest(PushDataServer &pds) : _pds(pds) {};
 	std::string generateJson(PushDataList::DataMap &dataMap) { return _pds.generateJson(dataMap); }
 	size_t size() { return _pds._middlewareList.size(); };
 	PushDataServer &_pds;


### PR DESCRIPTION
Here is a new PR targeting the formatting issue. A little more difficult than I had anticipated: It seems that recent ubuntu versions use clang-format V 1.8 even if we try to explicitly remove it before installing a more recent version. So I hard coded clang-format-20 for now, but this should be reset to the version agnostic clang-format, once ubuntu fixes this issue in later versions.