### PR TITLE
Add Home Assistant MQTT Discovery support

### DIFF
--- a/etc/vzlogger.conf
+++ b/etc/vzlogger.conf
@@ -52,7 +52,13 @@
         "retain": false, // optional use retain message flag
         "rawAndAgg": false, // optional publish raw values even if agg mode is used
         "qos": 0, // optional quality of service, default is 0
-        "timestamp": false // optional whether to include a timestamp in the payload
+        "timestamp": false, // optional whether to include a timestamp in the payload
+        "ha_discovery": {                  // optional Home Assistant MQTT Discovery
+            "enabled": false,              // off by default
+            "prefix": "homeassistant",     // optional, HA discovery topic prefix
+            "device_name": "vzlogger",     // optional, name of the HA device entry
+            "device_identifier": ""        // optional, defaults to mqtt.id or device_name
+        }
     },
 
     // Meter configuration

--- a/include/mqtt.hpp
+++ b/include/mqtt.hpp
@@ -49,12 +49,23 @@ class MqttClient {
 	int _qos = 0;
 	bool _timestamp = false;
 
+	// Home Assistant MQTT Discovery
+	// (https://www.home-assistant.io/integrations/mqtt/#mqtt-discovery)
+	bool _haEnabled = false;
+	std::string _haPrefix;           // discovery prefix, defaults to "homeassistant"
+	std::string _haDeviceName;       // HA device name, defaults to "vzlogger"
+	std::string _haDeviceIdentifier; // HA device identifier, defaults to client id
+
+	void parseHaDiscoveryConfig(struct json_object *option);
+	void publishHaDiscovery(Channel &ch, const std::string &stateTopic, bool aggregated);
+
 	bool _isConnected = false;
 
 	struct mosquitto *_mcs = nullptr; // mosquitto client session data
 
 	struct ChannelEntry {
 		bool _announced = false;
+		bool _haAnnounced = false;
 		bool _sendRaw = true;
 		bool _sendAgg = true;
 		std::string _fullTopicRaw;

--- a/include/mqtt_ha_discovery.hpp
+++ b/include/mqtt_ha_discovery.hpp
@@ -1,0 +1,45 @@
+/*
+ * Home Assistant MQTT Discovery helpers.
+ *
+ * Kept separate from mqtt.cpp / libmosquitto so the metadata lookup and
+ * config-JSON assembly can be unit-tested without a broker.
+ */
+
+#ifndef __mqtt_ha_discovery_hpp_
+#define __mqtt_ha_discovery_hpp_
+
+#include <string>
+
+struct json_object; // forward decl, defined by libjson-c
+
+namespace vz {
+namespace mqtt_ha {
+
+struct ObisHaMeta {
+	const char *unit;
+	const char *deviceClass;
+	const char *stateClass;
+	const char *defaultName;
+};
+
+// Look up Home Assistant sensor metadata for an OBIS identifier in canonical
+// form (e.g. "1-0:1.8.0*255"). Returns nullptr if the code is unknown.
+const ObisHaMeta *lookupObisHa(const std::string &obisKey);
+
+// Build a Home Assistant MQTT Discovery config JSON object. Caller takes
+// ownership of the returned object and must release it with json_object_put.
+//
+// - meta may be nullptr (unknown OBIS) — unit/device_class/state_class are
+//   then omitted.
+// - When timestampPayload is true a value_template extracting `value_json.value`
+//   is added; otherwise the raw payload is consumed as-is.
+struct json_object *buildDiscoveryConfig(const std::string &uniqueId, const std::string &sensorName,
+										 const std::string &stateTopic, bool timestampPayload,
+										 const ObisHaMeta *meta,
+										 const std::string &deviceIdentifier,
+										 const std::string &deviceName);
+
+} // namespace mqtt_ha
+} // namespace vz
+
+#endif

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,7 +17,7 @@ else(LOCAL_SUPPORT)
 endif(LOCAL_SUPPORT)
 
 if(ENABLE_MQTT)
-  set(mqtt_srcs mqtt.cpp)
+  set(mqtt_srcs mqtt.cpp mqtt_ha_discovery.cpp)
 else(ENABLE_MQTT)
   set(mqtt_srcs "")
 endif(ENABLE_MQTT)

--- a/src/mqtt.cpp
+++ b/src/mqtt.cpp
@@ -6,6 +6,7 @@
 #include "mqtt.hpp"
 #include "common.h"
 #include "mosquitto.h"
+#include "mqtt_ha_discovery.hpp"
 #include <cassert>
 #include <sstream>
 #include <unistd.h>
@@ -63,6 +64,8 @@ MqttClient::MqttClient(struct json_object *option) : _enabled(false) {
 				_timestamp = json_object_get_boolean(local_value);
 			} else if (strcmp(key, "id") == 0 && local_type == json_type_string) {
 				_id = json_object_get_string(local_value);
+			} else if (strcmp(key, "ha_discovery") == 0 && local_type == json_type_object) {
+				parseHaDiscoveryConfig(local_value);
 			} else {
 				print(log_alert, "Ignoring invalid field or type: %s=%s", NULL, key,
 					  json_object_get_string(local_value));
@@ -77,6 +80,16 @@ MqttClient::MqttClient(struct json_object *option) : _enabled(false) {
 		_topic = std::string("vzlogger/");
 	else
 		_topic += '/';
+
+	// HA discovery defaults
+	if (_haEnabled) {
+		if (!_haPrefix.length())
+			_haPrefix = "homeassistant";
+		if (!_haDeviceName.length())
+			_haDeviceName = "vzlogger";
+		if (!_haDeviceIdentifier.length())
+			_haDeviceIdentifier = _id.length() ? _id : _haDeviceName;
+	}
 
 	// mosquitto lib init:
 	if (mosquitto_lib_init() != MOSQ_ERR_SUCCESS) {
@@ -219,6 +232,72 @@ MqttClient::~MqttClient() {
 	mosquitto_lib_cleanup(); // this assumes nobody else is using libmosquitto!
 }
 
+void MqttClient::parseHaDiscoveryConfig(struct json_object *option) {
+	if (!option)
+		return;
+	json_object_object_foreach(option, key, value) {
+		enum json_type type = json_object_get_type(value);
+		if (strcmp(key, "enabled") == 0 && type == json_type_boolean) {
+			_haEnabled = json_object_get_boolean(value);
+		} else if (strcmp(key, "prefix") == 0 && type == json_type_string) {
+			_haPrefix = json_object_get_string(value);
+		} else if (strcmp(key, "device_name") == 0 && type == json_type_string) {
+			_haDeviceName = json_object_get_string(value);
+		} else if (strcmp(key, "device_identifier") == 0 && type == json_type_string) {
+			_haDeviceIdentifier = json_object_get_string(value);
+		} else {
+			print(log_alert, "Ignoring invalid ha_discovery field: %s", NULL, key);
+		}
+	}
+}
+
+void MqttClient::publishHaDiscovery(Channel &ch, const std::string &stateTopic, bool aggregated) {
+	if (!_mcs)
+		return;
+
+	// Resolve OBIS identifier (if any) for metadata lookup.
+	std::string obisKey;
+	char unparseBuf[200] = {0};
+	if (ch.identifier() && ch.identifier()->unparse(unparseBuf, sizeof(unparseBuf))) {
+		obisKey = unparseBuf;
+	}
+	const vz::mqtt_ha::ObisHaMeta *meta = vz::mqtt_ha::lookupObisHa(obisKey);
+
+	// Unique id derived from channel UUID (dashes stripped for an entity-id friendly slug).
+	std::string uuid = ch.uuid() ? ch.uuid() : "";
+	std::string slug;
+	slug.reserve(uuid.size());
+	for (char c : uuid) {
+		if (c != '-')
+			slug.push_back(c);
+	}
+	if (slug.empty())
+		slug = ch.name() ? ch.name() : "channel";
+	const std::string uniqueId = "vzlogger_" + slug;
+
+	std::string sensorName = meta ? meta->defaultName : (obisKey.length() ? obisKey : uniqueId);
+	if (aggregated)
+		sensorName += " (agg)";
+
+	struct json_object *cfg = vz::mqtt_ha::buildDiscoveryConfig(
+		uniqueId, sensorName, stateTopic, _timestamp, meta, _haDeviceIdentifier, _haDeviceName);
+
+	const std::string discoveryTopic = _haPrefix + "/sensor/" + uniqueId + "/config";
+	const char *payload = json_object_to_json_string(cfg);
+	int payloadLen = static_cast<int>(strlen(payload));
+	// HA Discovery requires the config topic to be retained so HA picks it up on reconnect.
+	int res = mosquitto_publish(_mcs, 0, discoveryTopic.c_str(), payloadLen, payload, _qos, true);
+	if (res != MOSQ_ERR_SUCCESS) {
+		print(log_warning, "HA discovery publish to %s failed: %s", "mqtt", discoveryTopic.c_str(),
+			  mosquitto_strerror(res));
+	} else {
+		print(log_finest, "HA discovery published %s -> state=%s", "mqtt", discoveryTopic.c_str(),
+			  stateTopic.c_str());
+	}
+
+	json_object_put(cfg);
+}
+
 void MqttClient::ChannelEntry::generateNames(const std::string &prefix, Channel &ch) {
 	_announceValues.clear();
 	_fullTopicRaw = prefix;
@@ -282,6 +361,15 @@ void MqttClient::publish(Channel::Ptr ch, Reading &rds, bool aggregate) {
 				entry._announced = true; // if one can be announced we treat it successfull
 			}
 		}
+	}
+
+	// Publish Home Assistant MQTT Discovery config once per channel. The state_topic
+	// follows whichever data stream is actually being emitted (agg-only vs. raw).
+	if (_haEnabled && !entry._haAnnounced) {
+		const bool aggOnly = entry._sendAgg && !entry._sendRaw;
+		const std::string &stateTopic = aggOnly ? entry._fullTopicAgg : entry._fullTopicRaw;
+		publishHaDiscovery(*ch, stateTopic, aggOnly);
+		entry._haAnnounced = true;
 	}
 
 	std::string &topic = aggregate ? entry._fullTopicAgg : entry._fullTopicRaw;

--- a/src/mqtt_ha_discovery.cpp
+++ b/src/mqtt_ha_discovery.cpp
@@ -1,0 +1,88 @@
+/*
+ * Home Assistant MQTT Discovery helpers — see include/mqtt_ha_discovery.hpp.
+ */
+
+#include "mqtt_ha_discovery.hpp"
+#include <json-c/json.h>
+#include <unordered_map>
+
+namespace vz {
+namespace mqtt_ha {
+
+namespace {
+
+// Mapping from OBIS identifiers (as produced by ObisIdentifier::unparse) to
+// Home Assistant sensor metadata. Extend as needed; unknown OBIS codes return
+// nullptr and the caller falls back to a unit-less generic sensor.
+const std::unordered_map<std::string, ObisHaMeta> &obisHaMap() {
+	static const std::unordered_map<std::string, ObisHaMeta> map = {
+		{"1-0:1.8.0*255", {"Wh", "energy", "total_increasing", "Active energy import (total)"}},
+		{"1-0:1.8.1*255", {"Wh", "energy", "total_increasing", "Active energy import (tariff 1)"}},
+		{"1-0:1.8.2*255", {"Wh", "energy", "total_increasing", "Active energy import (tariff 2)"}},
+		{"1-0:2.8.0*255", {"Wh", "energy", "total_increasing", "Active energy export (total)"}},
+		{"1-0:2.8.1*255", {"Wh", "energy", "total_increasing", "Active energy export (tariff 1)"}},
+		{"1-0:2.8.2*255", {"Wh", "energy", "total_increasing", "Active energy export (tariff 2)"}},
+		{"1-0:16.7.0*255", {"W", "power", "measurement", "Active power (sum)"}},
+		{"1-0:1.7.0*255", {"W", "power", "measurement", "Active power import"}},
+		{"1-0:2.7.0*255", {"W", "power", "measurement", "Active power export"}},
+		{"1-0:36.7.0*255", {"W", "power", "measurement", "Active power L1"}},
+		{"1-0:56.7.0*255", {"W", "power", "measurement", "Active power L2"}},
+		{"1-0:76.7.0*255", {"W", "power", "measurement", "Active power L3"}},
+		{"1-0:32.7.0*255", {"V", "voltage", "measurement", "Voltage L1"}},
+		{"1-0:52.7.0*255", {"V", "voltage", "measurement", "Voltage L2"}},
+		{"1-0:72.7.0*255", {"V", "voltage", "measurement", "Voltage L3"}},
+		{"1-0:31.7.0*255", {"A", "current", "measurement", "Current L1"}},
+		{"1-0:51.7.0*255", {"A", "current", "measurement", "Current L2"}},
+		{"1-0:71.7.0*255", {"A", "current", "measurement", "Current L3"}},
+	};
+	return map;
+}
+
+} // namespace
+
+const ObisHaMeta *lookupObisHa(const std::string &obisKey) {
+	const auto &map = obisHaMap();
+	auto it = map.find(obisKey);
+	return it == map.end() ? nullptr : &it->second;
+}
+
+struct json_object *buildDiscoveryConfig(const std::string &uniqueId, const std::string &sensorName,
+										 const std::string &stateTopic, bool timestampPayload,
+										 const ObisHaMeta *meta,
+										 const std::string &deviceIdentifier,
+										 const std::string &deviceName) {
+	struct json_object *cfg = json_object_new_object();
+
+	json_object_object_add(cfg, "name", json_object_new_string(sensorName.c_str()));
+	json_object_object_add(cfg, "unique_id", json_object_new_string(uniqueId.c_str()));
+	json_object_object_add(cfg, "object_id", json_object_new_string(uniqueId.c_str()));
+	json_object_object_add(cfg, "state_topic", json_object_new_string(stateTopic.c_str()));
+
+	if (timestampPayload) {
+		json_object_object_add(cfg, "value_template",
+							   json_object_new_string("{{ value_json.value }}"));
+	}
+
+	if (meta) {
+		if (meta->unit)
+			json_object_object_add(cfg, "unit_of_measurement", json_object_new_string(meta->unit));
+		if (meta->deviceClass)
+			json_object_object_add(cfg, "device_class", json_object_new_string(meta->deviceClass));
+		if (meta->stateClass)
+			json_object_object_add(cfg, "state_class", json_object_new_string(meta->stateClass));
+	}
+
+	struct json_object *device = json_object_new_object();
+	struct json_object *identifiers = json_object_new_array();
+	json_object_array_add(identifiers, json_object_new_string(deviceIdentifier.c_str()));
+	json_object_object_add(device, "identifiers", identifiers);
+	json_object_object_add(device, "name", json_object_new_string(deviceName.c_str()));
+	json_object_object_add(device, "manufacturer", json_object_new_string("volkszaehler.org"));
+	json_object_object_add(device, "model", json_object_new_string("vzlogger"));
+	json_object_object_add(cfg, "device", device);
+
+	return cfg;
+}
+
+} // namespace mqtt_ha
+} // namespace vz

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -49,8 +49,10 @@ else(OCR_TESSERACT_SUPPORT)
 endif(OCR_TESSERACT_SUPPORT)
 
 if(ENABLE_MQTT)
-    list(APPEND test_sources ../src/mqtt.cpp)
+    list(APPEND test_sources ../src/mqtt.cpp ../src/mqtt_ha_discovery.cpp)
     list(APPEND test_libraries ${MQTT_LIBRARY})
+else(ENABLE_MQTT)
+    list(REMOVE_ITEM test_sources ${CMAKE_CURRENT_SOURCE_DIR}/ut_mqtt_ha_discovery.cpp)
 endif(ENABLE_MQTT)
 
 if(OMS_SUPPORT)

--- a/tests/mocks/CMakeLists.txt
+++ b/tests/mocks/CMakeLists.txt
@@ -5,7 +5,7 @@ if(LOCAL_SUPPORT)
 endif(LOCAL_SUPPORT)
 
 if(ENABLE_MQTT)
-	set(mock_mqtt_sources ../../src/mqtt.cpp)
+	set(mock_mqtt_sources ../../src/mqtt.cpp ../../src/mqtt_ha_discovery.cpp)
 else(ENABLE_MQTT)
 	set(mock_mqtt_sources "")
 endif(ENABLE_MQTT)

--- a/tests/ut_mqtt_ha_discovery.cpp
+++ b/tests/ut_mqtt_ha_discovery.cpp
@@ -1,0 +1,102 @@
+#include "mqtt_ha_discovery.hpp"
+#include "gtest/gtest.h"
+#include <json-c/json.h>
+#include <string>
+
+using vz::mqtt_ha::buildDiscoveryConfig;
+using vz::mqtt_ha::lookupObisHa;
+using vz::mqtt_ha::ObisHaMeta;
+
+namespace {
+
+std::string jsonField(json_object *obj, const char *key) {
+	json_object *v = nullptr;
+	if (!json_object_object_get_ex(obj, key, &v))
+		return "";
+	return json_object_get_string(v);
+}
+
+bool jsonHas(json_object *obj, const char *key) {
+	json_object *v = nullptr;
+	return json_object_object_get_ex(obj, key, &v);
+}
+
+} // namespace
+
+TEST(MqttHaDiscovery, LookupKnownEnergyImport) {
+	const ObisHaMeta *m = lookupObisHa("1-0:1.8.0*255");
+	ASSERT_NE(m, nullptr);
+	EXPECT_STREQ(m->unit, "Wh");
+	EXPECT_STREQ(m->deviceClass, "energy");
+	EXPECT_STREQ(m->stateClass, "total_increasing");
+}
+
+TEST(MqttHaDiscovery, LookupKnownActivePower) {
+	const ObisHaMeta *m = lookupObisHa("1-0:16.7.0*255");
+	ASSERT_NE(m, nullptr);
+	EXPECT_STREQ(m->unit, "W");
+	EXPECT_STREQ(m->deviceClass, "power");
+	EXPECT_STREQ(m->stateClass, "measurement");
+}
+
+TEST(MqttHaDiscovery, LookupUnknownReturnsNull) {
+	EXPECT_EQ(lookupObisHa("1-0:99.99.99*255"), nullptr);
+	EXPECT_EQ(lookupObisHa(""), nullptr);
+}
+
+TEST(MqttHaDiscovery, BuildConfigWithKnownObis) {
+	const ObisHaMeta *m = lookupObisHa("1-0:1.8.0*255");
+	ASSERT_NE(m, nullptr);
+
+	json_object *cfg = buildDiscoveryConfig("vzlogger_abc", "Bezug", "vzlogger/chn0/raw",
+											/*timestampPayload=*/false, m, "vzlogger", "vzlogger");
+	ASSERT_NE(cfg, nullptr);
+
+	EXPECT_EQ(jsonField(cfg, "name"), "Bezug");
+	EXPECT_EQ(jsonField(cfg, "unique_id"), "vzlogger_abc");
+	EXPECT_EQ(jsonField(cfg, "object_id"), "vzlogger_abc");
+	EXPECT_EQ(jsonField(cfg, "state_topic"), "vzlogger/chn0/raw");
+	EXPECT_EQ(jsonField(cfg, "unit_of_measurement"), "Wh");
+	EXPECT_EQ(jsonField(cfg, "device_class"), "energy");
+	EXPECT_EQ(jsonField(cfg, "state_class"), "total_increasing");
+	EXPECT_FALSE(jsonHas(cfg, "value_template"));
+
+	json_object *device = nullptr;
+	ASSERT_TRUE(json_object_object_get_ex(cfg, "device", &device));
+	EXPECT_EQ(jsonField(device, "name"), "vzlogger");
+	EXPECT_EQ(jsonField(device, "manufacturer"), "volkszaehler.org");
+	EXPECT_EQ(jsonField(device, "model"), "vzlogger");
+
+	json_object *ids = nullptr;
+	ASSERT_TRUE(json_object_object_get_ex(device, "identifiers", &ids));
+	ASSERT_EQ(json_object_get_type(ids), json_type_array);
+	ASSERT_EQ(json_object_array_length(ids), 1);
+	EXPECT_STREQ(json_object_get_string(json_object_array_get_idx(ids, 0)), "vzlogger");
+
+	json_object_put(cfg);
+}
+
+TEST(MqttHaDiscovery, BuildConfigWithoutMetaOmitsUnit) {
+	json_object *cfg =
+		buildDiscoveryConfig("vzlogger_x", "x", "vzlogger/chn0/raw",
+							 /*timestampPayload=*/false, /*meta=*/nullptr, "vzlogger", "vzlogger");
+	ASSERT_NE(cfg, nullptr);
+
+	EXPECT_FALSE(jsonHas(cfg, "unit_of_measurement"));
+	EXPECT_FALSE(jsonHas(cfg, "device_class"));
+	EXPECT_FALSE(jsonHas(cfg, "state_class"));
+	EXPECT_FALSE(jsonHas(cfg, "value_template"));
+
+	json_object_put(cfg);
+}
+
+TEST(MqttHaDiscovery, BuildConfigWithTimestampAddsValueTemplate) {
+	json_object *cfg =
+		buildDiscoveryConfig("vzlogger_x", "x", "vzlogger/chn0/raw",
+							 /*timestampPayload=*/true, /*meta=*/nullptr, "vzlogger", "vzlogger");
+	ASSERT_NE(cfg, nullptr);
+
+	EXPECT_EQ(jsonField(cfg, "value_template"), "{{ value_json.value }}");
+
+	json_object_put(cfg);
+}


### PR DESCRIPTION
## Summary

Adds opt-in Home Assistant MQTT Discovery to the existing MQTT client. When enabled,
vzlogger publishes retained discovery configs (`<prefix>/sensor/vzlogger_<uuid>/config`)
for each channel on first reading, letting Home Assistant auto-create sensors with the
correct `unit_of_measurement`, `device_class` and `state_class` derived from the
channel's OBIS identifier.

## Why

Today every Home Assistant user running vzlogger needs to hand-write a YAML sensor
block per channel just to give the raw `smartmeter/reading/chnN/raw` topic a unit
and a meaningful name. Doing this once inside vzlogger removes that boilerplate and
makes the readings show up in HA as proper Energy / Power / Voltage / Current sensors
out of the box.

## Design notes

- **Opt-in.** `ha_discovery.enabled` defaults to `false` — no behaviour change for
  existing setups.
- **No new dependencies.** Discovery JSON is built with the already-linked `libjson-c`.
- **Lazy publish.** The discovery config is sent once per channel, hooked next to the
  existing per-channel announce flow in `MqttClient::publish()`. Channels without
  readings never produce discovery topics.
- **Static OBIS map** with 18 common SML codes (1.8.0/1.8.1/1.8.2, 2.8.0/2.8.1/2.8.2,
  16.7.0, 1.7.0, 2.7.0, 36/56/76.7.0, 32/52/72.7.0, 31/51/71.7.0). Unknown OBIS codes
  fall back to a unit-less generic sensor.
- **`value_template`** is only emitted when `mqtt.timestamp=true` (JSON payload);
  otherwise the raw numeric payload is consumed directly by HA.
- **Separate translation unit** (`src/mqtt_ha_discovery.cpp`) for the metadata lookup
  and config-JSON assembly so they can be unit-tested without a broker.
- **One HA device per vzlogger process** (`vzlogger` by default, configurable via
  `device_name` / `device_identifier`). Per-meter grouping would require a
  `Channel`→`Meter` back-reference and is intentionally left as a follow-up to keep
  this PR contained.

## Config

```jsonc
"mqtt": {
    "enabled": true,
    "host": "…",
    "topic": "smartmeter/reading",
    "ha_discovery": {
        "enabled": true,             // opt in
        "prefix": "homeassistant",   // optional, HA discovery prefix
        "device_name": "vzlogger",   // optional, HA device name
        "device_identifier": ""      // optional, defaults to mqtt.id or device_name
    }
}
```

## Tests

Adds `tests/ut_mqtt_ha_discovery.cpp` with 6 gtest cases covering:

- Lookup of known OBIS metadata (energy import, active power)
- Lookup of unknown OBIS returns `nullptr`
- Discovery-JSON shape for a known OBIS (verifies `name`, `unique_id`, `state_topic`,
  `unit_of_measurement`, `device_class`, `state_class`, `device.*`)
- Unknown-meta path omits `unit_of_measurement`, `device_class`, `state_class`
- `timestamp: true` adds the `value_template`

All existing tests still pass.

## Test plan

- [x] `docker build --build-arg build_test=on .` succeeds
- [x] `vzlogger_unit_tests`, `mock_metermap`, `mock_MeterW1therm`, `mock_MeterOMS`,
      `mock_MeterS0` — 5/5 passing via `make test`
- [x] `MqttHaDiscovery.*` — 6/6 passing
- [x] `./check-formatting.sh` clean (verified in an `ubuntu:latest` container with
      `clang-format-20`)
- [x] Smoke-tested against a real Mosquitto broker and Home Assistant 2025.x; sensors
      appear under the `vzlogger` device with correct units (Wh / W) and the Energy
      Dashboard picks up the `total_increasing` energy sensors.