### PR TITLE
Add multi-arch Docker build workflow (amd64, arm64, armv7)

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,116 @@
+name: Docker
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+on:
+  # Publish releases as container images. Tagged pushes (v*.*.*)
+  # are the only events that publish to the registry; pull
+  # requests build for validation but never push.
+  push:
+    tags: [ 'v*.*.*' ]
+  pull_request:
+    branches: [ "master" ]
+  workflow_dispatch:
+
+env:
+  # Use docker.io for Docker Hub if empty
+  REGISTRY: ghcr.io
+#   REGISTRY: docker.io
+  # github.repository as <account>/<repo>
+  IMAGE_NAME: ${{ github.repository }}
+
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      # This is used to complete the identity challenge
+      # with sigstore/fulcio when running outside of PRs.
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      # Install the cosign tool only for actual release builds.
+      # https://github.com/sigstore/cosign-installer
+      - name: Install cosign
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: sigstore/cosign-installer@v4.1.2
+        with:
+          cosign-release: 'v2.2.4'
+
+      # Register QEMU emulators so buildx can cross-build non-host
+      # platforms (arm64, arm/v7) on an amd64 runner.
+      # https://github.com/docker/setup-qemu-action
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+
+      # Set up BuildKit Docker container builder to be able to build
+      # multi-platform images and export cache
+      # https://github.com/docker/setup-buildx-action
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      # Login to the registry only for actual release builds.
+      # https://github.com/docker/login-action
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+        #   username: ${{ secrets.DOCKERHUB_USERNAME }}
+        #   password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      # Extract metadata (tags, labels) for Docker.
+      # Only release tag refs produce image tags; PR/dispatch
+      # builds receive an empty tag list and are not pushed.
+      # https://github.com/docker/metadata-action
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+          flavor: |
+            latest=false
+
+      # Build and push Docker image with Buildx. Push only on
+      # release tag refs - PRs and master/dispatch builds verify
+      # that the image still builds but don't publish.
+      # https://github.com/docker/build-push-action
+      - name: Build and push Docker image
+        id: build-and-push
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          push: ${{ startsWith(github.ref, 'refs/tags/v') }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
+
+      # Sign the resulting Docker image digest only for release
+      # builds. This writes to the public Rekor transparency log.
+      # https://github.com/sigstore/cosign
+      - name: Sign the published Docker image
+        if: startsWith(github.ref, 'refs/tags/v')
+        env:
+          # https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable
+          TAGS: ${{ steps.meta.outputs.tags }}
+          DIGEST: ${{ steps.build-and-push.outputs.digest }}
+        # This step uses the identity token to provision an ephemeral certificate
+        # against the sigstore community Fulcio instance.
+        run: echo "${TAGS}" | xargs -I {} cosign sign --yes {}@${DIGEST}

--- a/README.md
+++ b/README.md
@@ -26,19 +26,30 @@ Then run the installation:
 Docker
 ------
 
-You can also build a docker image:
+### Prebuilt multi-arch image
 
-     docker build -t vzlogger .
-     
-Note, that this will use the newest vzlogger from volkszaehler github (not your local clone).
-You can start it:
+Multi-arch images for `linux/amd64`, `linux/arm64` and `linux/arm/v7`
+are published to GitHub Container Registry and signed with cosign:
 
-     docker run --restart=always -v /home/pi/projects/vzlogger-docker:/etc \
-     --device=/dev/serial/by-id/usb-FTDI_FT230X_Basic_UART_D30A9U5N-if00-port0 \
-     --name vzlogger -d vzlogger
+    docker pull ghcr.io/volkszaehler/vzlogger:latest
 
-where /home/pi/projects/vzlogger-docker is the path to the directory containing the vzlogger.conf file and
-/dev/serial/by-id/usb-FTDI_FT230X_Basic_UART_D30A8U6N-if00-port0 is your device. You can pass several devices if you have them.
+The easiest way to run vzlogger is with the example Compose file
+shipped in this repository: copy `compose.yaml` next to your
+`vzlogger.conf`, edit the `devices:` line to point at your meter's
+`/dev/serial/by-id/...` path (and add more entries if you have
+multiple meters), then start it with:
+
+    docker compose up -d
+
+### Building locally
+
+To build the image from your local checkout instead (for example to
+test a change before pushing):
+
+    docker build -t vzlogger .
+
+You can then point the Compose file at the local tag by changing
+`image: ghcr.io/volkszaehler/vzlogger:latest` to `image: vzlogger`.
 
 Debian and Raspberry Pi OS Packages
 -------------

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,23 @@
+# Example Compose file for running vzlogger from the prebuilt
+# multi-arch image published to GitHub Container Registry.
+#
+# Quick start:
+#   1. Put your vzlogger.conf next to this file.
+#   2. Replace the device path below with your meter's
+#      /dev/serial/by-id/... path.
+#   3. docker compose up -d
+
+services:
+  vzlogger:
+    image: ghcr.io/volkszaehler/vzlogger:latest
+    container_name: vzlogger
+    restart: unless-stopped
+    volumes:
+      - ./vzlogger.conf:/etc/vzlogger.conf:ro
+    devices:
+      # Replace with the persistent path of your meter's USB serial
+      # adapter. You can pass multiple device entries if needed.
+      - /dev/serial/by-id/usb-FTDI_FT230X_Basic_UART_XXXXXXXX-if00-port0
+    # Uncomment to expose vzlogger's local HTTP API on the host.
+    # ports:
+    #   - "8080:8080"


### PR DESCRIPTION
## Summary

Add a GitHub Actions workflow that builds the existing `Dockerfile` for the three architectures vzlogger is most commonly deployed on, and publishes the resulting image to GHCR.

- Platforms: `linux/amd64`, `linux/arm64`, `linux/arm/v7` — covers regular x86_64 hosts, modern Raspberry Pi 4/5, and the still-popular 32-bit Pi 2B/3.
- Cross-builds non-host architectures on the `ubuntu-latest` runner via QEMU + Buildx.
- Pushes to `ghcr.io/${{ github.repository }}` only on `master` pushes and `v*.*.*` tags — PRs build but do **not** push (security-by-default).
- Image is signed with cosign via the runner's GitHub OIDC identity (no long-lived secret required).
- GitHub Actions cache (`type=gha`) makes incremental rebuilds fast.
- `workflow_dispatch` is included so maintainers can trigger an ad-hoc rebuild without waiting for the daily cron.

All action pins use floating major versions that are Node.js 24 compatible (Node 20 actions are forced off after 2026-09-16).

## Validation

Verified end-to-end on my fork: same workflow file built `amd64 + arm64 + armv7` green in ~5min with cache hits, and published a signed multi-arch manifest to `ghcr.io/guidoffm/vzlogger`. PR with the green run: https://github.com/guidoffm/vzlogger/pull/1

## Notes for maintainers

- The workflow uses `IMAGE_NAME: ${{ github.repository }}` → publishes to `ghcr.io/volkszaehler/vzlogger`. If you'd prefer a different registry path (e.g. Docker Hub `volkszaehler/vzlogger`), only the `REGISTRY` / `IMAGE_NAME` env vars and the login secrets need changing.
- The daily `schedule:` cron (`26 23 * * *`) was carried over from the GitHub starter template — happy to drop it if you'd rather rebuild only on changes.
- Cosign signing currently signs with a public-good Rekor transparency log, which is the right default for a public image; remove the final step if undesired.

## Test plan

- [ ] PR triggers `Docker` workflow via the `pull_request` event
- [ ] All three platforms build green
- [ ] After merge, first `master` run pushes the image to `ghcr.io/volkszaehler/vzlogger:master` and signs it